### PR TITLE
shadcn 컴포넌트 install 시 tailwindcss 파일에서 플러그인 js 부분을 문자열로 자동 전환되는 이슈

### DIFF
--- a/app/globals-custom.css
+++ b/app/globals-custom.css
@@ -1,0 +1,116 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@font-face {
+  font-family: 'Pretendard';
+  src: url('https://fastly.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Regular.woff')
+    format('woff');
+  font-weight: 400;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: 'Pretendard';
+  src: url('https://fastly.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Medium.woff')
+    format('woff');
+  font-weight: 500;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: 'Pretendard';
+  src: url('https://fastly.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-SemiBold.woff')
+    format('woff');
+  font-weight: 600;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: 'Pretendard';
+  src: url('https://fastly.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Bold.woff')
+    format('woff');
+  font-weight: 700;
+  font-style: normal;
+}
+
+@layer base {
+  :root {
+    --background: #fff;
+    --border: rgba(248, 250, 252, 0.5);
+
+    /* brand */
+    --brand-primary: #10b981;
+    --brand-secondary: #34d399;
+    --brand-tertiary: #a3e635;
+    --brand-gradient: linear-gradient(
+      90deg,
+      #10b981 0%,
+      #a3e635 100%
+    );
+
+    /* point */
+    --p-purple: #a855f7;
+    --p-blue: #3b82f6;
+    --p-cyan: #06b6d4;
+    --p-pink: #ec4899;
+    --p-rose: #f43f5e;
+    --p-orange: #f97316;
+    --p-yellow: #eab308;
+
+    /* background */
+    --b-primary-dark: #0f172a;
+    --b-primary-light: #ffffff;
+    --b-secondary-dark: #1e293b;
+    --b-secondary-light: #f1f5f9;
+    --b-tertiary-dark: #334155;
+    --b-tertiary-light: #e2e8f0;
+    --b-inverse: #ffffff;
+
+    /* interactive */
+    --i-inactive: #94a3b8;
+    --i-hover: #059669;
+    --i-pressed: #047857;
+    --i-focus: #10b981;
+
+    /* text */
+    --t-primary-dark: #f8fafc;
+    --t-primary-light: #1e293b;
+    --t-secondary: #cbd5e1;
+    --t-tertiary: #e2e8f0;
+    --t-default: #64748b;
+    --t-inverse: #ffffff;
+    --t-disabled: #94a3b8;
+
+    /* status */
+    --s-danger: #dc2626;
+
+    /* icon */
+    --icon-primary: #64748b;
+    --icon-inverse: #f8fafc;
+    --icon-brand: #10b981;
+  }
+  .dark {
+    --background: #0f172a;
+    --border: rgba(248, 250, 252, 0.5);
+    --b-primary-light: var(--b-primary-dark);
+    --b-secondary-light: var(--b-secondary-dark);
+    --b-tertiary-light: var(--b-tertiary-dark);
+    --t-primary-light: var(--t-primary-dark);
+  }
+
+  .light {
+    --b-primary-dark: var(--b-primary-light);
+    --b-secondary-dark: var(--b-secondary-light);
+    --b-tertiary-dark: var(--b-tertiary-light);
+    --t-primary-dark: var(--t-primary-light);
+  }
+}
+@layer base {
+  * {
+    @apply border-border font-sans;
+  }
+  body {
+    @apply text-t-primary;
+  }
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,43 +1,8 @@
 @tailwind base;
-@tailwind components;
-@tailwind utilities;
-
-@font-face {
-  font-family: 'Pretendard';
-  src: url('https://fastly.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Regular.woff')
-    format('woff');
-  font-weight: 400;
-  font-style: normal;
-}
-
-@font-face {
-  font-family: 'Pretendard';
-  src: url('https://fastly.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Medium.woff')
-    format('woff');
-  font-weight: 500;
-  font-style: normal;
-}
-
-@font-face {
-  font-family: 'Pretendard';
-  src: url('https://fastly.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-SemiBold.woff')
-    format('woff');
-  font-weight: 600;
-  font-style: normal;
-}
-
-@font-face {
-  font-family: 'Pretendard';
-  src: url('https://fastly.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Bold.woff')
-    format('woff');
-  font-weight: 700;
-  font-style: normal;
-}
 
 @layer base {
   :root {
-    /* shadcn color */
-    --background: 0 0% 100%;
+    --background: #ffffff;
     --foreground: 240 10% 3.9%;
     --card: 0 0% 100%;
     --card-foreground: 240 10% 3.9%;
@@ -62,65 +27,9 @@
     --chart-4: 43 74% 66%;
     --chart-5: 27 87% 67%;
     --radius: 0.5rem;
-
-    /* project color */
-    /* brand */
-    --brand-primary: #10b981;
-    --brand-secondary: #34d399;
-    --brand-tertiary: #a3e635;
-    --brand-gradient: linear-gradient(
-      90deg,
-      #10b981 0%,
-      #a3e635 100%
-    );
-
-    /* point */
-    --p-purple: #a855f7;
-    --p-blue: #3b82f6;
-    --p-cyan: #06b6d4;
-    --p-pink: #ec4899;
-    --p-rose: #f43f5e;
-    --p-orange: #f97316;
-    --p-yellow: #eab308;
-
-    /* background */
-    --b-primary-dark: #0f172a;
-    --b-primary-light: #ffffff;
-    --b-secondary-dark: #1e293b;
-    --b-secondary-light: #f1f5f9;
-    --b-tertiary-dark: #334155;
-    --b-tertiary-light: #e2e8f0;
-    --b-inverse: #ffffff;
-
-    /* interactive */
-    --i-inactive: #94a3b8;
-    --i-hover: #059669;
-    --i-pressed: #047857;
-    --i-focus: #10b981;
-
-    /* border */
-    --border-primary: rgba(248, 250, 252, 0.5);
-
-    /* text */
-    --t-primary-dark: #f8fafc;
-    --t-primary-light: #1e293b;
-    --t-secondary: #cbd5e1;
-    --t-tertiary: #e2e8f0;
-    --t-default: #64748b;
-    --t-inverse: #ffffff;
-    --t-disabled: #94a3b8;
-
-    /* status */
-    --s-danger: #dc2626;
-
-    /* icon */
-    --icon-primary: #64748b;
-    --icon-inverse: #f8fafc;
-    --icon-brand: #10b981;
   }
   .dark {
-    /* shadcn color */
-    --background: 240 10% 3.9%;
+    --background: #0f172a;
     --foreground: 0 0% 98%;
     --card: 240 10% 3.9%;
     --card-foreground: 0 0% 98%;
@@ -144,26 +53,13 @@
     --chart-3: 30 80% 55%;
     --chart-4: 280 65% 60%;
     --chart-5: 340 75% 55%;
-    /* project color */
-    --b-primary-light: var(--b-primary-dark);
-    --b-secondary-light: var(--b-secondary-dark);
-    --b-tertiary-light: var(--b-tertiary-dark);
-    --t-primary-light: var(--t-primary-dark);
-  }
-
-  .light {
-    /* project color */
-    --b-primary-dark: var(--b-primary-light);
-    --b-secondary-dark: var(--b-secondary-light);
-    --b-tertiary-dark: var(--b-tertiary-light);
-    --t-primary-dark: var(--t-primary-light);
   }
 }
 @layer base {
   * {
-    @apply border-border font-sans;
+    @apply border-border;
   }
   body {
-    @apply bg-background text-t-primary;
+    @apply text-foreground bg-background;
   }
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,6 +7,8 @@ import {
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 
 import './globals.css';
+import './globals-custom.css';
+
 import { ThemeProvider } from '@/utils/theme-provider';
 import DarkmodeToggle from '@/components/DarkmodeToggle';
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -45,6 +45,7 @@ const eslintConfig = [
     files: ['components/ui/**/*.{js,ts,jsx,tsx}'],
     rules: {
       'tailwindcss/enforces-shorthand': 'off',
+      'prettier/prettier': 'off',
     },
   },
 ];

--- a/tailwind-custom.config.ts
+++ b/tailwind-custom.config.ts
@@ -1,0 +1,80 @@
+import type { Config } from 'tailwindcss';
+
+const plugin = require('tailwindcss/plugin');
+
+// 공통 유틸리티 생성 함수
+interface GenerateSizesOptions {
+  limit: number;
+  divider: number;
+  prefix: string;
+}
+
+const generateSizes = ({
+  limit,
+  divider,
+  prefix,
+}: GenerateSizesOptions): Record<string, string> => {
+  const sizes: Record<string, string> = {};
+  for (let i = 0; i <= limit; i++) {
+    sizes[`${prefix}-${i}`] = `${i / divider}rem`;
+  }
+  return sizes;
+};
+
+export const customConfig: Config = {
+  content: [],
+  theme: {
+    extend: {
+      // 유틸리티 동적 생성
+      spacing: ({ theme }) => {
+        return generateSizes({
+          limit: theme('spacingLimit', 2000),
+          divider: theme('remDivider', 16),
+          prefix: 'pr',
+        });
+      },
+      borderRadius: ({ theme }) => {
+        return generateSizes({
+          limit: theme('borderRadiusLimit', 100),
+          divider: theme('remDivider', 16),
+          prefix: 'pr',
+        });
+      },
+    },
+    plugins: [
+      plugin(function ({
+        addUtilities,
+        theme,
+      }: {
+        addUtilities: (
+          utilities: Record<string, any>,
+          options?: { variants?: string[] },
+        ) => void;
+        theme: (path: string, defaultValue?: any) => any;
+      }) {
+        const fontSizeLimit = theme('fontSizeLimit', 100);
+        const remDivider = theme('remDivider', 16);
+
+        // fontSize 유틸리티 동적 생성
+        const fontSizes = generateSizes({
+          limit: fontSizeLimit,
+          divider: remDivider,
+          prefix: 'text-pr',
+        });
+
+        // Tailwind 유틸리티 추가
+        addUtilities(
+          Object.fromEntries(
+            Object.entries(fontSizes).map(
+              ([key, value]) => [
+                `.${key}`,
+                { fontSize: value },
+              ],
+            ),
+          ),
+          { variants: ['responsive'] },
+        );
+      }),
+    ],
+  },
+};

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,32 +1,13 @@
 import type { Config } from 'tailwindcss';
 import tailwindcssAnimate from 'tailwindcss-animate';
+import { customConfig } from './tailwind-custom.config';
 
-const plugin = require('tailwindcss/plugin');
-
-// 공통 유틸리티 생성 함수
-interface GenerateSizesOptions {
-  limit: number;
-  divider: number;
-  prefix: string;
-}
-
-const generateSizes = ({
-  limit,
-  divider,
-  prefix,
-}: GenerateSizesOptions): Record<string, string> => {
-  const sizes: Record<string, string> = {};
-  for (let i = 0; i <= limit; i++) {
-    sizes[`${prefix}-${i}`] = `${i / divider}rem`;
-  }
-  return sizes;
-};
-
-export default {
+const shadcnConfig: Config = {
   darkMode: ['class'],
   content: [
     './components/**/*.{js,ts,jsx,tsx,mdx}',
     './app/**/*.{js,ts,jsx,tsx,mdx}',
+    './globals.css',
   ],
   theme: {
     extend: {
@@ -34,8 +15,6 @@ export default {
         sans: ['Pretendard', 'Arial', 'sans-serif'],
       },
       colors: {
-        // REVIEW : shadcn option
-        // background: 'hsl(var(--background))',
         background: 'var(--b-primary-light)',
         foreground: 'hsl(var(--foreground))',
         card: {
@@ -66,9 +45,6 @@ export default {
           DEFAULT: 'hsl(var(--destructive))',
           foreground: 'hsl(var(--destructive-foreground))',
         },
-        // REVIEW : shadcn option
-        // border: 'hsl(var(--border))',
-        border: 'var(--border-primary)',
         input: 'hsl(var(--input))',
         ring: 'hsl(var(--ring))',
         chart: {
@@ -78,8 +54,7 @@ export default {
           '4': 'hsl(var(--chart-4))',
           '5': 'hsl(var(--chart-5))',
         },
-        // 컬러 커스텀
-        // Point 컬러
+        border: 'var(--border)',
         p: {
           purple: 'var(--point-purple)',
           blue: 'var(--point-blue)',
@@ -89,21 +64,18 @@ export default {
           orange: 'var(--point-orange)',
           yellow: 'var(--point-yellow)',
         },
-        // 브랜드 컬러
         brand: {
           primary: 'var(--brand-primary)',
           secondary: 'var(--brand-secondary)',
           tertiary: 'var(--brand-tertiary)',
           gradient: 'var(--brand-gradient)',
         },
-        // 배경색
         b: {
           primary: 'var(--b-primary-light)',
           secondary: 'var(--b-secondary-light)',
           tertiary: 'var(--b-tertiary-light)',
           inverse: 'var(--b-inverse)',
         },
-        // 텍스트 색상
         t: {
           primary: 'var(--t-primary-light)',
           secondary: 'var(--t-secondary)',
@@ -112,211 +84,258 @@ export default {
           inverse: 'var(--t-inverse)',
           disabled: 'var(--t-disabled)',
         },
-        // 상호작용 색상
         i: {
           inactive: 'var(--i-inactive)',
           hover: 'var(--i-hover)',
           pressed: 'var(--i-pressed)',
           focus: 'var(--i-focus)',
         },
-        // 기타 상태
         s: {
           danger: 'var(--s-danger)',
         },
-        // 아이콘 색상
         icon: {
           primary: 'var(--icon-primary)',
           inverse: 'var(--icon-inverse)',
           brand: 'var(--icon-brand)',
         },
       },
-      // REVIEW : shadcn option
-      // borderRadius: {
-      //   lg: 'var(--radius)',
-      //   md: 'calc(var(--radius) - 2px)',
-      //   sm: 'calc(var(--radius) - 4px)',
-      // },
       fontSize: {
-        12: [
+        '12': [
           '0.75rem',
-          { lineHeight: '0.875rem', fontWeight: '400' },
+          {
+            lineHeight: '0.875rem',
+            fontWeight: '400',
+          },
+        ],
+        '13': [
+          '0.8125rem',
+          {
+            lineHeight: '1rem',
+            fontWeight: '400',
+          },
+        ],
+        '14': [
+          '0.875rem',
+          {
+            lineHeight: '1.0625rem',
+            fontWeight: '400',
+          },
+        ],
+        '16': [
+          '1rem',
+          {
+            lineHeight: '1.1875rem',
+            fontWeight: '400',
+          },
+        ],
+        '18': [
+          '1.125rem',
+          {
+            lineHeight: '1.3125rem',
+            fontWeight: '400',
+          },
+        ],
+        '20': [
+          '1.25rem',
+          {
+            lineHeight: '1.5rem',
+            fontWeight: '400',
+          },
+        ],
+        '24': [
+          '1.5rem',
+          {
+            lineHeight: '1.75rem',
+            fontWeight: '400',
+          },
         ],
         '12m': [
           '0.75rem',
-          { lineHeight: '0.875rem', fontWeight: '500' },
+          {
+            lineHeight: '0.875rem',
+            fontWeight: '500',
+          },
         ],
         '12sb': [
           '0.75rem',
-          { lineHeight: '0.875rem', fontWeight: '600' },
-        ],
-        13: [
-          '0.8125rem',
-          { lineHeight: '1rem', fontWeight: '400' },
+          {
+            lineHeight: '0.875rem',
+            fontWeight: '600',
+          },
         ],
         '13m': [
           '0.8125rem',
-          { lineHeight: '1rem', fontWeight: '500' },
+          {
+            lineHeight: '1rem',
+            fontWeight: '500',
+          },
         ],
         '13sb': [
           '0.8125rem',
-          { lineHeight: '1rem', fontWeight: '600' },
-        ],
-        14: [
-          '0.875rem',
-          { lineHeight: '1.0625rem', fontWeight: '400' },
+          {
+            lineHeight: '1rem',
+            fontWeight: '600',
+          },
         ],
         '14m': [
           '0.875rem',
-          { lineHeight: '1.0625rem', fontWeight: '500' },
+          {
+            lineHeight: '1.0625rem',
+            fontWeight: '500',
+          },
         ],
         '14sb': [
           '0.875rem',
-          { lineHeight: '1.0625rem', fontWeight: '600' },
+          {
+            lineHeight: '1.0625rem',
+            fontWeight: '600',
+          },
         ],
         '14b': [
           '0.875rem',
-          { lineHeight: '1.0625rem', fontWeight: '700' },
-        ],
-        16: [
-          '1rem',
-          { lineHeight: '1.1875rem', fontWeight: '400' },
+          {
+            lineHeight: '1.0625rem',
+            fontWeight: '700',
+          },
         ],
         '16m': [
           '1rem',
-          { lineHeight: '1.1875rem', fontWeight: '500' },
+          {
+            lineHeight: '1.1875rem',
+            fontWeight: '500',
+          },
         ],
         '16sb': [
           '1rem',
-          { lineHeight: '1.1875rem', fontWeight: '600' },
+          {
+            lineHeight: '1.1875rem',
+            fontWeight: '600',
+          },
         ],
         '16b': [
           '1rem',
-          { lineHeight: '1.1875rem', fontWeight: '700' },
-        ],
-        18: [
-          '1.125rem',
-          { lineHeight: '1.3125rem', fontWeight: '400' },
+          {
+            lineHeight: '1.1875rem',
+            fontWeight: '700',
+          },
         ],
         '18m': [
           '1.125rem',
-          { lineHeight: '1.3125rem', fontWeight: '500' },
+          {
+            lineHeight: '1.3125rem',
+            fontWeight: '500',
+          },
         ],
         '18sb': [
           '1.125rem',
-          { lineHeight: '1.3125rem', fontWeight: '600' },
+          {
+            lineHeight: '1.3125rem',
+            fontWeight: '600',
+          },
         ],
         '18b': [
           '1.125rem',
-          { lineHeight: '1.3125rem', fontWeight: '700' },
-        ],
-        20: [
-          '1.25rem',
-          { lineHeight: '1.5rem', fontWeight: '400' },
+          {
+            lineHeight: '1.3125rem',
+            fontWeight: '700',
+          },
         ],
         '20m': [
           '1.25rem',
-          { lineHeight: '1.5rem', fontWeight: '500' },
+          {
+            lineHeight: '1.5rem',
+            fontWeight: '500',
+          },
         ],
         '20sb': [
           '1.25rem',
-          { lineHeight: '1.5rem', fontWeight: '600' },
+          {
+            lineHeight: '1.5rem',
+            fontWeight: '600',
+          },
         ],
         '20b': [
           '1.25rem',
-          { lineHeight: '1.5rem', fontWeight: '700' },
-        ],
-        24: [
-          '1.5rem',
-          { lineHeight: '1.75rem', fontWeight: '400' },
+          {
+            lineHeight: '1.5rem',
+            fontWeight: '700',
+          },
         ],
         '24m': [
           '1.5rem',
-          { lineHeight: '1.75rem', fontWeight: '500' },
+          {
+            lineHeight: '1.75rem',
+            fontWeight: '500',
+          },
         ],
         '24sb': [
           '1.5rem',
-          { lineHeight: '1.75rem', fontWeight: '600' },
+          {
+            lineHeight: '1.75rem',
+            fontWeight: '600',
+          },
         ],
         '24b': [
           '1.5rem',
-          { lineHeight: '1.75rem', fontWeight: '700' },
+          {
+            lineHeight: '1.75rem',
+            fontWeight: '700',
+          },
         ],
         '32sb': [
           '2rem',
-          { lineHeight: '2.375rem', fontWeight: '600' },
+          {
+            lineHeight: '2.375rem',
+            fontWeight: '600',
+          },
         ],
         '32b': [
           '2rem',
-          { lineHeight: '2.375rem', fontWeight: '700' },
+          {
+            lineHeight: '2.375rem',
+            fontWeight: '700',
+          },
         ],
         '40m': [
           '2.5rem',
-          { lineHeight: '3rem', fontWeight: '500' },
+          {
+            lineHeight: '3rem',
+            fontWeight: '500',
+          },
         ],
       },
       screens: {
-        mo: { max: '767px' }, // 모바일: 0 ~ 767px
-        ta: { min: '768px', max: '1279px' }, // 태블릿: 768px ~ 1279px
-        tamo: { max: '1279px' }, // 모바일+태블릿: 0 ~ 1279px
-      },
-
-      // 유틸리티 동적 생성
-      spacing: ({ theme }) => {
-        return generateSizes({
-          limit: theme('spacingLimit', 2000),
-          divider: theme('remDivider', 16),
-          prefix: 'pr',
-        });
-      },
-      borderRadius: ({ theme }) => {
-        return generateSizes({
-          limit: theme('borderRadiusLimit', 100),
-          divider: theme('remDivider', 16),
-          prefix: 'pr',
-        });
+        mo: {
+          max: '767px',
+        },
+        ta: {
+          min: '768px',
+          max: '1279px',
+        },
+        tamo: {
+          max: '1279px',
+        },
       },
     },
-    plugins: [
-      plugin(function ({
-        addUtilities,
-        theme,
-      }: {
-        addUtilities: (
-          utilities: Record<string, any>,
-          options?: { variants?: string[] },
-        ) => void;
-        theme: (path: string, defaultValue?: any) => any;
-      }) {
-        const fontSizeLimit = theme('fontSizeLimit', 100);
-        const remDivider = theme('remDivider', 16);
-
-        // fontSize 유틸리티 동적 생성
-        const fontSizes = generateSizes({
-          limit: fontSizeLimit,
-          divider: remDivider,
-          prefix: 'text-pr',
-        });
-
-        // Tailwind 유틸리티 추가
-        addUtilities(
-          Object.fromEntries(
-            Object.entries(fontSizes).map(
-              ([key, value]) => [
-                `.${key}`,
-                { fontSize: value },
-              ],
-            ),
-          ),
-          { variants: ['responsive'] },
-        );
-      }),
-    ],
+    plugins: ['tailwindcssAnimate'],
     theme: {
-      remDivider: 16, // 기본 remDivider 값 설정
-      fontSizeLimit: 100, // 폰트 크기 제한
-      spacingLimit: 2000, // 간격 제한
-      borderRadiusLimit: 100, // border-radius 제한
+      remDivider: 16,
+      fontSizeLimit: 100,
+      spacingLimit: 2000,
+      borderRadiusLimit: 100,
     },
   },
-  plugins: [tailwindcssAnimate],
+};
+export default {
+  ...shadcnConfig,
+  theme: {
+    extend: {
+      ...shadcnConfig.theme?.extend,
+      ...customConfig.theme?.extend,
+    },
+    plugins: {
+      ...shadcnConfig.theme?.plugins,
+      ...customConfig.theme?.plugins,
+    },
+  },
 } satisfies Config;


### PR DESCRIPTION
## 관련 이슈

<!-- 연관된 이슈 번호를 작성해주세요 예 #15 -->

fix #28

## 요약

<!-- 작업 내용에 대해 간단히 설명해주세요 -->
- shadcn 컴포넌트 install 시 tailwindcss 파일에서 플러그인 js 부분을 문자열로 자동 전환되는 이슈
- shadcn 컴포넌트 eslint prettier 규칙 무시
  - 계속 shadcn 내부 코드까지 eslint 규칙을 적용시켜버려서 무시하게끔 수정했습니다

## 변경 사항 설명

<!-- 구현한 내용에 대해 자세한 내용을 작성해 주세요 -->
- shadcn에서는 import 시 기본적으로 tailwind.config.ts를 바라보기때문에 tailwind.config.ts를 shadcn base 유틸로 두고, 별도의 tailwind-custom.config.ts 파일을 생성하여, pxr 단위변환에 대한 내역을 shadcn에서 간섭하지 못하도록 구분하였습니다.
- globals.css 또한 같이 변경이 되어서 기존 커스텀 color의 간섭을 막기 위해, 별도의 globals-custom.css를 생성하여 커스텀 컬러만 모아서 작성해주었습니다.
- 테스트 결과
  - pxr도 정상적으로 동작하고 shadcn 컴포넌트 중 tailwind.config.ts와 globalse.css을 변경하는 컴포넌트를 import 하였을 경우, 기존 커스텀 컬러에 간섭하지 않는 부분을 확인했습니다(선언 되어있는 컬러 한정)

## 주의 사항
- 만약 shadcn 컴포넌트 import 시 해당 pxr 플러그인과 스프레드 구문에 관섭이 발생한다면 @junghwa1996 저한테 이슈 전달 부탁드립니다.
