### PR TITLE
할 일 카드 Dropdown, Storybook 추가

### DIFF
--- a/app/globals-custom.css
+++ b/app/globals-custom.css
@@ -119,3 +119,8 @@
 .dropdown-item {
   @apply size-full cursor-pointer focus:bg-b-tertiary focus:outline-none;
 }
+
+/* kebab icon 스타일 */
+.icon-kebab {
+  @apply absolute left-0 top-0 size-pr-16 bg-[url('/images/icon-kebab.svg')];
+}

--- a/components/TaskCard/KebabButton.tsx
+++ b/components/TaskCard/KebabButton.tsx
@@ -4,9 +4,7 @@ function KebabButton({ taskId }: { taskId: number }) {
   return (
     <div className="ml-auto size-pr-16 mo:ml-0">
       <DropDown
-        trigger={
-          <button className="size-pr-16 shrink-0 bg-[url('/images/icon-kebab.svg')] text-xs" />
-        }
+        trigger={<button className="icon-kebab" />}
         items={[
           {
             text: '수정하기',

--- a/components/TaskCard/KebabButton.tsx
+++ b/components/TaskCard/KebabButton.tsx
@@ -1,6 +1,25 @@
-function KebabButton() {
+import DropDown from '../DropDown';
+
+function KebabButton({ taskId }: { taskId: number }) {
   return (
-    <button className="ml-auto size-pr-16 shrink-0 bg-[url('/images/icon-kebab.svg')] text-xs mo:ml-0" />
+    <div className="ml-auto size-pr-16 mo:ml-0">
+      <DropDown
+        trigger={
+          <button className="size-pr-16 shrink-0 bg-[url('/images/icon-kebab.svg')] text-xs" />
+        }
+        items={[
+          {
+            text: '수정하기',
+            onClick: () => alert(`${taskId} 할 일 카드 수정하기`),
+          },
+          {
+            text: '삭제하기',
+            onClick: () => alert(`${taskId} 할 일 카드 삭제하기`),
+          },
+        ]}
+        width="w-pr-120"
+      />
+    </div>
   );
 }
 

--- a/components/TaskCard/TaskCard.tsx
+++ b/components/TaskCard/TaskCard.tsx
@@ -26,7 +26,7 @@ const frequencyList: Record<
  * @returns {JSX.Element} 할 일 카드 컴포넌트
  */
 function TaskCard({ type, taskData }: TaskCardProps) {
-  const { name, date, doneAt, commentCount, frequency } = taskData;
+  const { id, name, date, doneAt, commentCount, frequency } = taskData;
   const [isChecked, setIsChecked] = useState(Boolean(doneAt));
   const isTaskList = type === 'taskList';
   const frequencyText = frequencyList[frequency];
@@ -52,7 +52,7 @@ function TaskCard({ type, taskData }: TaskCardProps) {
         {isTaskList && (
           <>
             <IconText type="commentCount" text={commentCount} />
-            <KebabButton />
+            <KebabButton taskId={id} />
           </>
         )}
       </CardContent>

--- a/stories/TaskCard.stories.tsx
+++ b/stories/TaskCard.stories.tsx
@@ -1,0 +1,66 @@
+import TaskCard from '@/components/TaskCard/TaskCard';
+import { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta<typeof TaskCard> = {
+  title: 'Components/TaskCard',
+  component: TaskCard,
+};
+
+export default meta;
+type Story = StoryObj<typeof TaskCard>;
+
+export const DAILY: Story = {
+  args: {
+    type: 'taskList',
+    taskData: {
+      id: 16166,
+      name: '팀미팅',
+      date: '2025-01-20T09:00:00+09:00',
+      doneAt: '2025-01-17T15:53:25+09:00',
+      commentCount: 23,
+      frequency: 'DAILY',
+    },
+  },
+};
+
+export const ONCE: Story = {
+  args: {
+    type: 'taskList',
+    taskData: {
+      id: 16166,
+      name: '팀미팅',
+      date: '2025-01-20T09:00:00+09:00',
+      doneAt: null,
+      commentCount: 0,
+      frequency: 'ONCE',
+    },
+  },
+};
+
+export const WEEKLY: Story = {
+  args: {
+    type: 'taskList',
+    taskData: {
+      id: 16166,
+      name: '팀미팅',
+      date: '2025-01-20T09:00:00+09:00',
+      doneAt: '2025-01-17T15:53:25+09:00',
+      commentCount: 0,
+      frequency: 'WEEKLY',
+    },
+  },
+};
+
+export const MONTHLY: Story = {
+  args: {
+    type: 'taskList',
+    taskData: {
+      id: 16166,
+      name: '팀미팅',
+      date: '2025-01-20T09:00:00+09:00',
+      doneAt: null,
+      commentCount: 0,
+      frequency: 'MONTHLY',
+    },
+  },
+};

--- a/types/taskCard.type.ts
+++ b/types/taskCard.type.ts
@@ -6,6 +6,7 @@ interface TaskCardProps {
 }
 
 interface taskData {
+  id: number;
   name: string;
   date: string;
   doneAt: string | null;


### PR DESCRIPTION
## 관련 이슈

close #66 

## 요약

- 할 일 컴포넌트 Dropdown추가
- 스토리북에 할 일 컴포넌트 추가

## 변경 사항 설명

- 이전 작업의 할 일 컴포넌트에 Dropdown 추가했습니다.

<img width="950" alt="스크린샷 2025-01-20 10 13 16" src="https://github.com/user-attachments/assets/1dc22196-412f-45d7-8bc1-d0d1c24e9721" />

- 스토리북에 할 일 컴포넌트 추가했습니다.

<img width="979" alt="스크린샷 2025-01-20 10 13 37" src="https://github.com/user-attachments/assets/62ab13bb-574d-4dbf-95b1-e783a5e3c78d" />

---

## 2025.01.20 10:50 추가
Dropdown의 kebab icon 버튼의 경우 다른 페이지에서도 사용되는 부분이라 `global-custom.css` 파일에 `icon-kebab` 클래스로 스타일 추가하였습니다. 작업하실 떄 참고 부탁드립니다!