### PR TITLE
팀 생성하기 기능 구현 및 store에 patch 

### DIFF
--- a/app/addteam/page.tsx
+++ b/app/addteam/page.tsx
@@ -1,23 +1,93 @@
 'use client';
 
+import { useState } from 'react';
+import Image from 'next/image';
+import { useRouter } from 'next/navigation';
+
+import { uploadImage } from '@/service/image.api';
+import useForm from '@/hooks/useForm';
 import InputField from '@/components/InputField/InputField';
 import Container from '@/components/layout/Container';
 import { Button } from '@/components/ui/button';
-import useForm from '@/hooks/useForm';
+import { Input } from '@/components/ui/input';
+import { createGroup } from '@/service/group.api';
 
 export default function AddTeamPage() {
-  const { formData, handleChange } = useForm({ name: '' });
+  const { formData, handleChange, setFormData } = useForm({
+    name: '',
+    image: '',
+  });
+  const [imageFile, setImageFile] = useState<File | null>(null);
+  const [imagePreview, setImagePreview] = useState<string | null>(null);
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const route = useRouter();
+
+  // STUB 기본 이미지
+  // TODO 이미지 업로드 컴포넌트 완료 시 대체함
+  const defaultImage = '/images/icon-profile-member-default.svg';
+
+  // STUB 이미지 업로드
+  const handleImageChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = e.target.files;
+    if (!files) return;
+    const file = files[0];
+    setImageFile(file);
+    const reader = new FileReader();
+    reader.readAsDataURL(file);
+
+    reader.onload = () => {
+      setImagePreview(reader.result as string);
+      const formData = new FormData();
+      formData.append('image', file, file.name);
+      uploadImage(formData);
+    };
+  };
+
+  // STUB 폼 제출
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    console.log(formData);
+
+    try {
+      if (!imageFile) {
+        alert('이미지를 업로드해주세요.');
+        return;
+      }
+
+      const formImageData = new FormData();
+      // STUB 새로운 FormData 인스턴스를 생성하고 이미지를 추가합니다.
+      formImageData.append('image', imageFile, imageFile.name);
+      const url = await uploadImage(formImageData);
+
+      // STUB 이미지 업로드가 완료되면 formData에 이미지 URL을 추가합니다.
+      const newFormData = { ...formData, image: url };
+      setFormData(newFormData);
+      console.log('이미지 업로드가 완료되었습니다', url);
+
+      // STUB 팀을 생성합니다.
+      const response = await createGroup(newFormData);
+      console.log('팀 생성이 완료되었습니다', response);
+
+      route.push(`/${response.id}`);
+    } catch (error) {
+      console.error(error);
+    }
   };
 
   return (
     <Container>
       <h1>팀생성</h1>
       <form onSubmit={handleSubmit}>
-        <input type="file" />
+        {/* TODO 이미지 업로드 컴포넌트 완료 시 대체함 */}
+        <Input type="file" name="image" onChange={handleImageChange} />
+        <Image
+          priority
+          src={imagePreview ? imagePreview : defaultImage}
+          alt="team image"
+          width={64}
+          height={64}
+          className="overflow-hidden rounded-full"
+        />
+
         <InputField
           value={formData.name}
           onChange={handleChange}

--- a/app/addteam/page.tsx
+++ b/app/addteam/page.tsx
@@ -11,6 +11,7 @@ import Container from '@/components/layout/Container';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { createGroup } from '@/service/group.api';
+import useUserStore from '@/stores/useUser.store';
 
 export default function AddTeamPage() {
   const { formData, handleChange, setFormData } = useForm({
@@ -19,6 +20,7 @@ export default function AddTeamPage() {
   });
   const [imageFile, setImageFile] = useState<File | null>(null);
   const [imagePreview, setImagePreview] = useState<string | null>(null);
+  const { user, setUser } = useUserStore();
 
   const route = useRouter();
 
@@ -65,7 +67,33 @@ export default function AddTeamPage() {
 
       // STUB 팀을 생성합니다.
       const response = await createGroup(newFormData);
+      response.teamId = '11-3';
       console.log('팀 생성이 완료되었습니다', response);
+
+      if (!user) {
+        console.error('사용자 정보가 없습니다.');
+        return;
+      }
+
+      // STUB 새로운 멤버십을 생성합니다.
+      const newMembership = {
+        userId: user?.id,
+        groupId: response.id,
+        userName: user?.nickname,
+        userEmail: user?.email,
+        userImage: user?.image ?? null,
+        role: 'ADMIN' as 'ADMIN' | 'MEMBER',
+        group: { ...response },
+      };
+
+      // STUB 사용자 정보(store)에 새로운 멤버십을 추가합니다.
+      const memberships = user?.memberships ? [...user.memberships] : [];
+      memberships.push(newMembership);
+
+      // STUB 사용자 정보(store)를 업데이트합니다.
+      if (user) {
+        setUser({ ...user, memberships });
+      }
 
       route.push(`/${response.id}`);
     } catch (error) {

--- a/types/group.type.ts
+++ b/types/group.type.ts
@@ -56,6 +56,7 @@ interface CreateGroupParams {
 }
 
 interface CreateGroupResponse {
+  teamId: string;
   updatedAt: string;
   createdAt: string;
   image: string | null;


### PR DESCRIPTION
## 관련 이슈

<!-- 연관된 이슈 번호를 작성해주세요 예 #15 -->

close #76 

## 요약

<!-- 작업 내용에 대해 간단히 설명해주세요 -->
- 이미지 업로드 시 프리뷰 및 팀 생성하기 POST 시 이미지 url POST 
- 팀 생성하기 POST 기능 구현
- POST `respones`를 `user store`에 저장

## 변경 사항 설명

<!-- 구현한 내용에 대해 자세한 내용을 작성해 주세요 -->
- `addteam.tsx` 에 팀 생성하기 POST 구현 했습니다.
- 이미지 업로드 시 프리뷰로 노출되게 구현 했습니다.
- 팀 생성하기 submit 시 새로운 `FormData`를 생성합니다. 이미지 POST 먼저 진행 후 받은 `response`를 기존 `FormData`에 추가하여, 생성 POST 진행
- `createGroup POST` 시 `teamId`는 `response`에 포함되어있지않는데, store 업데이트 타입에는 `teamId`가 포함되어야하기때문에 받은 `response`에 `teamId`를 포함시켜서 store 업데이트 진행

## 테스트 방식
- 로그인 > (팀 length가 0이어야 함) 로그인 후 메인으로 자동 리다이렉트 > 팀생성하기 UI 노출 > 팀 생성하기 클릭하여 `addteam`으로 이동 > 이미지와 팀 이름을 넣고 팀 생성하기 클릭 > 생성된 팀페이지로 이동
<!-- 추가적으로 리뷰를 원하는 부분을 알려주세요 -->

- https://github.com/fe11-part4-team3/coworkers/blob/69f5a9b933cc83c108a7ff5103da2c72a54ba065/app/addteam/page.tsx#L58-L66  여기 부분 @Woolegend 님 팀 수정하기 페이지에서도 동일하게 사용될 것 같아서 이미지를 넣으면 url로 변환해서 새로운 formData 생성하는 것 까지 포함된 커스텀 훅을 제작할지 고민중입니다 의견주세요

## 주의 사항
- store 업데이트는 정상적으로 완료는 되었습니다
- 하지만 headers에서 team 정보를 정상적으로 받아서 노출시킬 수 있을지는 headers 기능 부분이 작성되지않아서 테스트하지 못했습니다 @Woolegend @Gwanhoo 작업 완료되시면 팀 생성하기 후 정상적으로 store에서 가져와 노출이 되는지 확인하시고 노티 부탁드립니다
