### PR TITLE
input color 시안과 다름 이슈

### DIFF
--- a/app/globals-custom.css
+++ b/app/globals-custom.css
@@ -37,7 +37,8 @@
 @layer base {
   :root {
     --background: #fff;
-    --border: #e2e8f0;
+    --border: rgba(248, 250, 252, 1);
+    --input: #e2e8f0;
 
     /* brand */
     --brand-primary: #10b981;
@@ -101,7 +102,8 @@
 
     --ring: #10b981;
     --ring-color: #10b981;
-    --border: rgba(226, 232, 240, 0.1);
+    --border: rgba(248, 250, 252, 0.1);
+    --input: #343e4e;
   }
 
   .light {
@@ -135,10 +137,6 @@
 /* kebab icon 스타일 */
 .icon-kebab {
   @apply size-pr-16 rounded-full bg-[url('/images/icon-kebab.svg')] duration-300 hover:bg-primary/10 active:bg-primary/20;
-}
-
-.border-input {
-  border-color: var(--border);
 }
 
 .border-t-secondary {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -46,7 +46,7 @@ const shadcnConfig: Config = {
           DEFAULT: 'hsl(var(--destructive))',
           foreground: 'hsl(var(--destructive-foreground))',
         },
-        input: 'hsl(var(--input))',
+        input: 'var(--input)',
         ring: 'var(--ring)',
         chart: {
           '1': 'hsl(var(--chart-1))',


### PR DESCRIPTION
## 관련 이슈

<!-- 연관된 이슈 번호를 작성해주세요 예 #15 -->

close #91 

## 요약

- `globals-custom.css` 에 `:root -input `컬러 추가 (하드 컬러로 넣음, opacity X)
- `shadcn` `border-input` class에 커스텀 컬러로 변경

<!-- 작업 내용에 대해 간단히 설명해주세요 -->

## 변경 사항 설명

- 이슈 본문에 작성해두긴 했는데, 기존에 `input` `border`가 안보인다는 의견이 있어서 계속 살펴보니 시안이 opacity Inside로 들어가서(웹에서는 opcity가 있는 inside border는 코드적으로 좋지않으며, border 대신 box-shadow로 써야함) 맞지 않는 거였습니다.
- 이게 드롭다운이랑 셀렉트 `border`에는 영향이 없었던 이유는 서로 다른 디자이너분이 작업해주셨는지 해당 컴포넌트는 `Outside (--t-secondary) #334155` 로 작업이 되어서 영향이 없었던거였습니다....🥲
- `shadcn` `input` 컴포넌트를 사용 할 경우 `shadcn color`인 `border-input` 클래스가 붙게 됩니다. 그래서 `shadcn` `-input` 값을 제가 별도로 추가한 (하드하게 스포이드로 찍어서 나온 값) 컬러로 넣어두었습니다.

이게 디자이너 관점과 개발자 관점이 무척 상이한데요

[디자이너]
- 피그마에서 `opacity border`를 구현 시 `inside`로 들어가는게 맞긴 합니다.
- 이렇게 되면 사실상 `border`의 실제 차지하는 영역은 `0px` => 이유는? 피그마는 벡터 기반이라서 (일러스트와 동일)
- 만약 `outside`로 작업 할 경우 `border`의 `px`값을 먹이기위해서 `strok`를 `fill` 상태로 바꿔줘야함

[개발자]
- `opacity` `border`를 구현 시 웹에서는 기본적으로 피그마의 `outside`처럼 `1px`을 가지게 됩니다.
- 하지만 위에 작성해놨듯이 영역을 `0` 만큼 차지하는 영역을 웹에서는 무조건 `1px`을 먹고 들어가니 `1px`을 주지 않기 위해서 `box-shadow`로 구현하게 됩니다.
- `box-shadow: inset 0 0 0 1px var(--border);` => 이렇게 구현해야함

그래서 이게 왜 문제이느냐?
- 진짜 문제는 `input`에 있습니다.(그리고 shadcn..) `input`에서는 여러가지 상태를 다루는데요 `hover, focus, active`...
- 여기를 상태가 변경되는 컬러값마다 border-color가 아닌 box-shadow로 일반 border와 구분을 지어서 또 한번 작성을 해주어야 한다는 점 입니다.
- 심지어 드롭다운, 셀렉트 컨텐츠 border와 컬러값이 또 다릅니다....🫠
> tailwind에 box-shadow 관련 유틸 class를 찾아봤는데 inside border처럼 보이게하는 유틸 class는 없더군요 그래서 또 커스텀 class를 만들어야함...
- 이게 shadcn input에서는 custom class를 border-input으로 border의 값을 적용 시키고 있습니다.
- 여기를 shadow로 변경하게 되면 기본적으로 shadcn에서 제공하는 hover,focus,active 등등 사용 못함 (border none 처리를 해야해서)

결국 디자이너의 통일성이 무너지게 되면서 개발자의 일거리만 더 늘어난 셈 입니다...
저희는 프로젝트 학습 중이라 디자인이 크게 틀어져도 별 문제가 되진않아서 하드하게 `input border color`를 주었는데요...
실무에서는 이걸로 디자이너랑 박터지게 싸웁니다 👀

그래도 실무가면 FE 개발자들보다는 협업할때 디자이너분들이랑 많은 소통을 할텐데요
어느정도 디자인적 지식을 알고있으면 좋을것같아서 작성드립니다


<!-- 구현한 내용에 대해 자세한 내용을 작성해 주세요 -->
<!-- 추가적으로 리뷰를 원하는 부분을 알려주세요 -->

## 주의 사항
- 시안 상에 `border/primary` 인지 `text/secondary` 인지 구분하여 사용 부탁드립니다
