### PR TITLE
#106 그룹 리스트 관리를 위한 저장소 및 커스텀 훅 구현 

### DIFF
--- a/hooks/useGroupList.ts
+++ b/hooks/useGroupList.ts
@@ -1,0 +1,39 @@
+import { getGroupList } from '@/service/user.api';
+import useGroupStore from '@/stores/useGroup.store';
+import useUserStore from '@/stores/useUser.store';
+import { useQuery } from '@tanstack/react-query';
+import { useParams } from 'next/navigation';
+import { useEffect } from 'react';
+
+const useGroupList = () => {
+  const { currentGroup, setCurrentGroup } = useGroupStore((state) => state);
+  const { user } = useUserStore();
+  const { teamId } = useParams();
+  const groupId = teamId ? Number(teamId) : null;
+  const { data: groups, isPending } = useQuery({
+    queryKey: ['groups'],
+    queryFn: getGroupList,
+    enabled: !!user,
+  });
+
+  useEffect(() => {
+    if (!groupId || !groups || isPending) {
+      setCurrentGroup(null);
+      return;
+    }
+
+    const flag = groups.some((group) => {
+      if (group.id === groupId) {
+        setCurrentGroup(group);
+        return true;
+      }
+      return false;
+    });
+
+    if (!flag) setCurrentGroup(null);
+  }, [groupId, groups, isPending]);
+
+  return { groups: groups || null, isPending, currentGroup };
+};
+
+export default useGroupList;

--- a/stores/useGroup.store.ts
+++ b/stores/useGroup.store.ts
@@ -1,0 +1,13 @@
+import { create } from 'zustand';
+
+import { IGroup } from '@/types/group.type';
+
+const useGroupStore = create<{
+  currentGroup: IGroup | null;
+  setCurrentGroup: (group: IGroup | null) => void;
+}>((set) => ({
+  currentGroup: null,
+  setCurrentGroup: (group: IGroup | null) => set({ currentGroup: group }),
+}));
+
+export default useGroupStore;


### PR DESCRIPTION
## 관련 이슈

close #106 

## 변경 사항 설명

### `useGroupStore`

그룹과 관련된 여러 데이터를 보관하기 위한 저장소입니다.

현재는 사용자가 위치한 그룹에 대한 정보만을 보관합니다.

해당 저장소를 직접 컴포넌트에서 사용할 일은 없고

다음 설명한 커스텀 훅을 활용하시면 됩니다.

### `useGroupList`

`getGroupList`는 여러 컴포넌트에서 동시에 사용되는 함수입니다.

이를 각 컴포넌트 마다 useQuery를 사용해 세팅을 하는 것은 비효율적입니다.

그래서 `getGroupList` 사용을 쉽게 하기 위해 useGroupList 커스텀 훅을 구현했습니다.

해당 훅은 아래 프로퍼티를 제공합니다.

- `groups` :
  -  `getGroupList`로 응답받은 `IGroups[]` 타입의 응답 데이터
  - 비인증 상태이거나 응답을 받기 전에는 `null`이 저장됩니다.
  - useQuery로 캐싱되기 때문에 store에는 따로 저장하지 않았습니다.
- `isPending` :
  - 응답에 대한 로딩 여부
- `currentGroup` :
  - 현재 위치한 `group` 
  - 타입은 `IGroup`
  - 사용자가 위치한 경로의 `teamId`를 기반으로 현재 위치한 그룹을 `groups`에서 찾습니다.
  - 현재 경로에 `teamId`가 없거나 배열에 teamId와 일치하는 그룹이 없을 경우 `null`이 저장됩니다.
  - 해당 데이터는 `store`에서 관리됩니다.
