### PR TITLE
#116 그룹 데이터 저장소와 관리를 위한 커스텀 훅 구현

### DIFF
--- a/hooks/useGroup.ts
+++ b/hooks/useGroup.ts
@@ -1,0 +1,77 @@
+import { getGroup } from '@/service/group.api';
+import useGroupStore from '@/stores/useGroup.stroe';
+import { useQuery } from '@tanstack/react-query';
+import { useCallback, useEffect } from 'react';
+
+/**
+ * getGroup으로 불러온 데이터를 관리합니다.
+ *
+ * @param {number | null} groupId 현재 경로의 그룹(팀) ID
+ *
+ * **사용법**
+ * ```ts
+ * const { teamId } = usePatams();
+ * const { ... } = useGroup(teamId);
+ * ```
+ *
+ * @returns
+ * - `group` : 현재 위치한 그룹 데이터. `getGroup`의 반환값
+ * - `members` : 그룹에 속한 멤버 목록 데이터. `group`에서 파싱
+ * - `taskLists` : 그룹에 속한 할 일 목록 배열. `group`에서 파싱
+ * - `isPending` : `getGroup` 요청 및 갱신 중
+ * - `clear` : `group`과 `group`에서 파싱된 데이터를 `null`로 초기화
+ * - `reload` : `getGroup` 강제 리페칭
+ */
+const useGroup = (groupId: number | null) => {
+  const {
+    group,
+    members,
+    taskLists,
+    setGroup,
+    setMembers,
+    setTaskLists,
+    clearStore,
+  } = useGroupStore();
+  const { data, isPending, refetch } = useQuery({
+    queryKey: ['group'],
+    queryFn: () => {
+      return groupId ? getGroup({ id: groupId }) : null;
+    },
+  });
+
+  const storeGroup = useCallback(() => {
+    setGroup(data || null);
+  }, [data, setGroup]);
+
+  const storeMembers = useCallback(() => {
+    data?.members && data.members.length > 0
+      ? setMembers(data.members)
+      : setMembers(null);
+  }, [data, setMembers]);
+
+  const storeTaskLists = useCallback(() => {
+    data?.taskLists && data.taskLists.length > 0
+      ? setTaskLists(data.taskLists)
+      : setTaskLists(null);
+  }, [data, setTaskLists]);
+
+  const clear = () => clearStore();
+  const reload = () => refetch();
+
+  useEffect(() => {
+    storeGroup();
+    storeMembers();
+    storeTaskLists();
+  }, [data]);
+
+  return {
+    group,
+    members,
+    taskLists,
+    isPending: !!groupId && isPending,
+    clear,
+    reload,
+  };
+};
+
+export default useGroup;

--- a/stores/useGroup.stroe.ts
+++ b/stores/useGroup.stroe.ts
@@ -1,0 +1,46 @@
+import { IGroupDetail, IMember, TaskListSummary } from '@/types/group.type';
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+interface IUseGroupStore {
+  group: IGroupDetail | null;
+  members: IMember[] | null;
+  taskLists: TaskListSummary[] | null;
+  setGroup: (group: IGroupDetail | null) => void;
+  setMembers: (members: IMember[] | null) => void;
+  setTaskLists: (taskLists: TaskListSummary[] | null) => void;
+  clearStore: () => void;
+}
+
+/**
+ * 현재 경로상 위치한 그룹(팀)과 관련된 데이터를 관리합니다.
+ *
+ * @name `group-store`
+ *
+ * @interface `IUseGroupStore`
+ * @property `group` : 현재 위치한 그룹(팀) 데이터
+ * @property `members` : 현제 그룹에 속한 멤버 목록 데이터
+ * @property `taskLists` : 현재 그룹에 속한 할 일 목록 배열 데이터
+ * @property `setGroup` : 그룹 데이터 설정 함수
+ * @property `setMembers` : 멤버 목록 데이터 설정 함수
+ * @property `settaskLists` : 할 일 목록 배열 설정 함수
+ * @property `clearStore` : 저장소에서 관리하는 데이터 `null`로 초기화
+ */
+const useGroupStore = create(
+  persist<IUseGroupStore>(
+    (set) => ({
+      group: null,
+      members: null,
+      taskLists: null,
+      setGroup: (group) => set({ group }),
+      setMembers: (members) => set({ members }),
+      setTaskLists: (taskLists) => set({ taskLists }),
+      clearStore: () => set({ group: null, members: null, taskLists: null }),
+    }),
+    {
+      name: 'group-store',
+    },
+  ),
+);
+
+export default useGroupStore;


### PR DESCRIPTION
## 관련 이슈

close #116 

## 요약

경로상 현재 위한 그룹의 데이터 저장소와 이를 관리할 커스텀 훅을 구현합니다.
> 현재 경로가 `/1234` 혹은 `/1234/tasklist`일 때, 위치한 그룹은 `ID`가 `1234`인 그룹입니다.

## 변경 사항 설명

### 저장소 useGroupStore

`zustand`로 구현한 저장소입니다.

해당 저장소에 대한 설명은 스크립트 파일의 주석으로도 남겨져 있습니다.

**※사용법**

```ts
/**
 * 현재 경로상 위치한 그룹(팀)과 관련된 데이터를 관리합니다.
 *
 * @name `group-store`
 *
 * @interface `IUseGroupStore`
 * @property `group` : 현재 위치한 그룹(팀) 데이터
 * @property `members` : 현제 그룹에 속한 멤버 목록 데이터
 * @property `taskLists` : 현재 그룹에 속한 할 일 목록 배열 데이터
 * @property `setGroup` : 그룹 데이터 설정 함수
 * @property `setMembers` : 멤버 목록 데이터 설정 함수
 * @property `settaskLists` : 할 일 목록 배열 설정 함수
 * @property `clearStore` : 저장소에서 관리하는 데이터 `null`로 초기화
 */
```

### 커스텀 훅 useGroup

현재 위치한 그룹의 데이터를 관리하기 위한 커스텀 훅입니다.

해당 훅은 `getGroup`으로 요청한 데이터를 관리합니다.

 **사용법**
 ```ts
 const { teamId } = usePatams();
 const { ... } = useGroup(teamId);
 ```

해당 훅에 대한 설명은 스크립트 파일의 주석으로도 남겨져 있습니다.

```ts
/**
 * getGroup으로 불러온 데이터를 관리합니다.
 *
 * @param {number | null} groupId 현재 경로의 그룹(팀) ID
 *
 * @returns
 * - `group` : 현재 위치한 그룹 데이터. `getGroup`의 반환값
 * - `members` : 그룹에 속한 멤버 목록 데이터. `group`에서 파싱
 * - `taskLists` : 그룹에 속한 할 일 목록 배열. `group`에서 파싱
 * - `isPending` : `getGroup` 요청 및 갱신 중
 * - `clear` : `group`과 `group`에서 파싱된 데이터를 `null`로 초기화
 * - `reload` : `getGroup` 강제 리페칭
 */
```

사용법에 대한 추가적인 문의는 @Woolegend 로 부탁 드립니다.