### PR TITLE
자유게시판 게시글 상세 페이지 댓글 입력 textarea

### DIFF
--- a/components/ArticleCommentTextarea/ArticleCommentTextarea.tsx
+++ b/components/ArticleCommentTextarea/ArticleCommentTextarea.tsx
@@ -1,6 +1,8 @@
 import { ChangeEvent } from 'react';
+
 import TextareaField from '@/components/InputField/TextareaField';
-import Buttons from '../Buttons';
+import Buttons from '@/components/Buttons';
+import { useDeviceType } from '@/contexts/DeviceTypeContext';
 
 interface ArticleCommentTextareaProps {
   commentValue: string;
@@ -19,6 +21,9 @@ function ArticleCommentTextarea({
   handleCommentChange,
   handleCommentSubmit,
 }: ArticleCommentTextareaProps) {
+  const deviceType = useDeviceType();
+  const mobile = deviceType === 'mobile';
+
   return (
     <>
       <TextareaField
@@ -36,7 +41,7 @@ function ArticleCommentTextarea({
           disabled={commentValue === ''}
           onClick={handleCommentSubmit}
           bg="default"
-          size="S"
+          size={!mobile ? 'XL' : 'S'}
           loading={false}
           rounded={false}
           width="w-pr-184 mo:w-pr-74"

--- a/components/ArticleCommentTextarea/ArticleCommentTextarea.tsx
+++ b/components/ArticleCommentTextarea/ArticleCommentTextarea.tsx
@@ -1,0 +1,49 @@
+import { ChangeEvent } from 'react';
+import TextareaField from '@/components/InputField/TextareaField';
+import Buttons from '../Buttons';
+
+interface ArticleCommentTextareaProps {
+  commentValue: string;
+  handleCommentChange: (e: ChangeEvent<HTMLTextAreaElement>) => void;
+  handleCommentSubmit: () => void;
+}
+
+/**
+ * @param {string} props.commentValue - textarea 입력 값
+ * @param {Function} props.handleCommentChange - textarea 입력 값 변경 이벤트
+ * @param {Function} props.handleCommentSubmit - textarea 입력 값 등록
+ * @returns {JSX.Element} - 자유게시판 게시글 상세 댓글 입력 컴포넌트
+ */
+function ArticleCommentTextarea({
+  commentValue,
+  handleCommentChange,
+  handleCommentSubmit,
+}: ArticleCommentTextareaProps) {
+  return (
+    <>
+      <TextareaField
+        name="content"
+        value={commentValue}
+        size="lg"
+        label="댓글달기"
+        placeholder="댓글을 입력해주세요."
+        onChange={handleCommentChange}
+      />
+
+      <div className="mt-pr-16 flex justify-end">
+        <Buttons
+          text="등록"
+          disabled={commentValue === ''}
+          onClick={handleCommentSubmit}
+          bg="default"
+          size="S"
+          loading={false}
+          rounded={false}
+          width="w-pr-184 mo:w-pr-74"
+        />
+      </div>
+    </>
+  );
+}
+
+export default ArticleCommentTextarea;

--- a/components/ArticleCommentTextarea/ArticleCommentTextarea.tsx
+++ b/components/ArticleCommentTextarea/ArticleCommentTextarea.tsx
@@ -17,7 +17,7 @@ interface ArticleCommentTextareaProps {
  * @returns {JSX.Element} - 자유게시판 게시글 상세 댓글 입력 컴포넌트
  */
 function ArticleCommentTextarea({
-  commentValue,
+  commentValue = '',
   handleCommentChange,
   handleCommentSubmit,
 }: ArticleCommentTextareaProps) {

--- a/components/TaskCommentTextarea/TaskCommentTextarea.tsx
+++ b/components/TaskCommentTextarea/TaskCommentTextarea.tsx
@@ -10,7 +10,7 @@ export interface CommentTextareaProps {
  * @param {Function} props.onChange - textarea 입력 값 변경 이벤트
  * @returns
  */
-function CommentTextarea({ value, onChange }: CommentTextareaProps) {
+function TaskCommentTextarea({ value, onChange }: CommentTextareaProps) {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   useEffect(() => {
@@ -41,4 +41,4 @@ function CommentTextarea({ value, onChange }: CommentTextareaProps) {
   );
 }
 
-export default CommentTextarea;
+export default TaskCommentTextarea;

--- a/components/TaskCommentTextarea/TaskCommentTextarea.tsx
+++ b/components/TaskCommentTextarea/TaskCommentTextarea.tsx
@@ -1,6 +1,6 @@
 import { ChangeEvent, useEffect, useRef } from 'react';
 
-export interface CommentTextareaProps {
+export interface TaskCommentTextareaProps {
   value: string;
   onChange: (e: ChangeEvent<HTMLTextAreaElement>) => void;
 }
@@ -8,9 +8,9 @@ export interface CommentTextareaProps {
 /**
  * @param {string} props.value - textarea 입력 값
  * @param {Function} props.onChange - textarea 입력 값 변경 이벤트
- * @returns
+ * @returns {JSX.Element} - 할 일 상세 댓글 입력 컴포넌트
  */
-function TaskCommentTextarea({ value, onChange }: CommentTextareaProps) {
+function TaskCommentTextarea({ value, onChange }: TaskCommentTextareaProps) {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   useEffect(() => {

--- a/stories/ArticleCommentTextarea.stories.tsx
+++ b/stories/ArticleCommentTextarea.stories.tsx
@@ -1,0 +1,13 @@
+import ArticleCommentTextarea from '@/components/ArticleCommentTextarea/ArticleCommentTextarea';
+import { Meta, StoryFn } from '@storybook/react';
+
+export default {
+  title: 'Components/ArticleCommentTextarea',
+  component: ArticleCommentTextarea,
+} as Meta;
+
+const Template: StoryFn<typeof ArticleCommentTextarea> = (args) => (
+  <ArticleCommentTextarea {...args} />
+);
+
+export const Default = Template.bind({});

--- a/stories/CommentTextarea.stories.tsx
+++ b/stories/CommentTextarea.stories.tsx
@@ -1,15 +1,15 @@
-import CommentTextarea, {
+import TaskCommentTextarea, {
   CommentTextareaProps,
-} from '@/components/CommentTextarea/CommentTextarea';
+} from '@/components/TaskCommentTextarea/TaskCommentTextarea';
 import { Meta, StoryFn } from '@storybook/react';
 
 export default {
-  title: 'Components/CommentTextarea',
-  component: CommentTextarea,
+  title: 'Components/TaskCommentTextarea',
+  component: TaskCommentTextarea,
 } as Meta;
 
 const Template: StoryFn<CommentTextareaProps> = (args) => (
-  <CommentTextarea {...args} />
+  <TaskCommentTextarea {...args} />
 );
 
 export const Default = Template.bind({});

--- a/stories/TaskCommentTextarea.stories.tsx
+++ b/stories/TaskCommentTextarea.stories.tsx
@@ -1,5 +1,5 @@
 import TaskCommentTextarea, {
-  CommentTextareaProps,
+  TaskCommentTextareaProps,
 } from '@/components/TaskCommentTextarea/TaskCommentTextarea';
 import { Meta, StoryFn } from '@storybook/react';
 
@@ -8,7 +8,7 @@ export default {
   component: TaskCommentTextarea,
 } as Meta;
 
-const Template: StoryFn<CommentTextareaProps> = (args) => (
+const Template: StoryFn<TaskCommentTextareaProps> = (args) => (
   <TaskCommentTextarea {...args} />
 );
 


### PR DESCRIPTION
## 관련 이슈

close #118 

## 요약

- 자유게시판 게시글 상세 댓글 입력 컴포넌트 작업
- 스토리북 추가

## 변경 사항 설명

- 자유게시판 게시글 상세 페이지의 댓글 입력 컴포넌트 작업했습니다.
- 스토리북에서 확인 가능하십니다.
<img width="1023" alt="스크린샷 2025-01-24 10 35 18" src="https://github.com/user-attachments/assets/12128134-8dce-4ee7-83ea-d3ac7a5dfedf" />
<img width="1028" alt="스크린샷 2025-01-24 10 35 39" src="https://github.com/user-attachments/assets/20f687b0-11ac-4b4c-aac4-8405daa0a12a" />
<img width="377" alt="스크린샷 2025-01-24 10 36 04" src="https://github.com/user-attachments/assets/d5659cb9-f23e-4dae-9fe3-67e43a7048a7" />
