### PR TITLE
#124 비밀번호 초기화 기능 구현

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -2,12 +2,17 @@
 
 import React, { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
+import { useMutation } from '@tanstack/react-query';
 
 import { signIn } from '@/service/auth.api';
 import useForm from '@/hooks/useForm';
 import Container from '@/components/layout/Container';
 import { Button } from '@/components/ui/button';
 import useUser from '@/hooks/useUser';
+import InputField from '@/components/InputField/InputField';
+import Buttons from '@/components/Buttons';
+import { resetPasswordEmail } from '@/service/user.api';
+import { ResetPasswordEmailParams } from '@/types/user.type';
 
 function LoginPage() {
   const { formData, handleChange } = useForm({
@@ -50,6 +55,26 @@ function LoginPage() {
     }
   }, [user, route, isAuthenticated]);
 
+  // 비밀번호 찾기 클릭 상태
+  const [isForgotPassword, setIsForgotPassword] = useState(false);
+
+  // 비밀번호 찾기 폼
+  const { formData: createResetUrl, handleChange: handleEailChange } =
+    useForm<ResetPasswordEmailParams>({
+      email: '',
+      redirectUrl: 'http://localhost:3000',
+    });
+
+  // 비밀번호 찾기 요청
+  const { mutate: resetPasswordMutate, isPending } = useMutation({
+    mutationFn: resetPasswordEmail,
+    onSuccess: (message) => {
+      alert(message);
+      setIsForgotPassword(false);
+    },
+    onError: (error) => console.error('비밀번호 재설정 실패:', error),
+  });
+
   // 로그인 상태가 아닐 때
   return (
     <Container>
@@ -80,7 +105,39 @@ function LoginPage() {
           </label>
         </div>
         {error && <p style={{ color: 'red' }}>{error}</p>}
+
         <Button type="submit">로그인</Button>
+
+        {/* 비밀번호 찾기 모달 오픈 버튼 */}
+        <button
+          className="text-16m text-brand-primary underline"
+          onClick={() => setIsForgotPassword(true)}
+        >
+          비밀번호를 잊으셨나요?
+        </button>
+
+        {/* TODO 임의 비밀번호 재설정 모달 */}
+        {isForgotPassword && (
+          <div>
+            <h2>비밀번호 재설정</h2>
+            <p>비밀번호 재설정 링크를 보내드립니다.</p>
+            <InputField
+              label="이메일"
+              type="email"
+              name="email"
+              value={createResetUrl.email}
+              onChange={handleEailChange}
+              placeholder="이메일을 입력하세요"
+            />
+            <Buttons
+              text="링크 보내기"
+              bg="default"
+              size="XL"
+              onClick={() => resetPasswordMutate(createResetUrl)}
+              disabled={isPending}
+            />
+          </div>
+        )}
       </form>
     </Container>
   );

--- a/app/reset-password/page.tsx
+++ b/app/reset-password/page.tsx
@@ -6,7 +6,7 @@ import { useMutation } from '@tanstack/react-query';
 
 import { resetPassword } from '@/service/user.api';
 import useForm from '@/hooks/useForm';
-import useUser from '@/hooks/useUser';
+// import useUser from '@/hooks/useUser';
 import InputField from '@/components/InputField/InputField';
 import Container from '@/components/layout/Container';
 import Buttons from '@/components/Buttons';
@@ -15,8 +15,6 @@ import Buttons from '@/components/Buttons';
  * STUB 비밀번호 초기화 페이지
  */
 export default function ResetPasswordPage() {
-  useUser(false);
-
   // STUB 비밀번호 초기화 토큰 가져오기
   const searchParams = useSearchParams();
   const resetToken = searchParams.get('token');

--- a/app/reset-password/page.tsx
+++ b/app/reset-password/page.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useMutation } from '@tanstack/react-query';
+
+import { resetPassword } from '@/service/user.api';
+import useForm from '@/hooks/useForm';
+import useUser from '@/hooks/useUser';
+import InputField from '@/components/InputField/InputField';
+import Container from '@/components/layout/Container';
+import Buttons from '@/components/Buttons';
+
+/**
+ * STUB 비밀번호 초기화 페이지
+ */
+export default function ResetPasswordPage() {
+  useUser(false);
+
+  // STUB 비밀번호 초기화 토큰 가져오기
+  const searchParams = useSearchParams();
+  const resetToken = searchParams.get('token');
+
+  // STUB 비밀번호 초기화 폼
+  const { formData: updatePasswordData, handleChange: handlePasswordChange } =
+    useForm({
+      password: '',
+      passwordConfirmation: '',
+      token: '',
+    });
+
+  const route = useRouter();
+
+  // STUB 토큰이 있을 경우 초기화 폼에 토큰 추가
+  useEffect(() => {
+    if (resetToken) {
+      updatePasswordData.token = resetToken;
+    }
+  }, []);
+
+  // STUB 비밀번호 초기화 요청
+  const { mutateAsync: resetPasswordMutation, isPending: isReset } =
+    useMutation({
+      mutationFn: resetPassword,
+      onSuccess: () => {
+        alert('비밀번호가 성공적으로 변경되었습니다.');
+        route.push('/login');
+      },
+      onError: (error) => console.error('비밀번호 초기화 실패:', error),
+    });
+
+  // STUB 비밀번호 초기화 폼 제출
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    resetPasswordMutation(updatePasswordData);
+  };
+
+  return (
+    <Container>
+      <h1>비밀번호 재설정</h1>
+
+      <form onSubmit={handleSubmit}>
+        <InputField
+          type="password"
+          label="새 비밀번호"
+          name="password"
+          autoComplete="new-password"
+          required
+          onChange={handlePasswordChange}
+          value={updatePasswordData.password}
+          placeholder="비밀번호 (영문, 숫자 포함, 12자 이내)를 입력해주세요."
+        />
+        <InputField
+          type="password"
+          label="비밀번호 확인"
+          name="passwordConfirmation"
+          autoComplete="new-password"
+          required
+          onChange={handlePasswordChange}
+          value={updatePasswordData.passwordConfirmation}
+          placeholder="새 비밀번호를 다시 한번 입력해주세요."
+        />
+        <Buttons
+          type="submit"
+          text="재설정"
+          bg="default"
+          size="XL"
+          disabled={isReset}
+        />
+      </form>
+    </Container>
+  );
+}

--- a/types/buttons.type.ts
+++ b/types/buttons.type.ts
@@ -32,7 +32,7 @@ type ButtonsLinkProps = ButtonsBaseProps &
 // onClick 속성이 있는 경우 (클릭 버튼)
 type ButtonsClickProps = ButtonsBaseProps &
   (LoadingTrueProps | LoadingFalseProps) & {
-    onClick: () => void;
+    onClick?: () => void;
     href?: never;
   };
 

--- a/types/inputField.type.ts
+++ b/types/inputField.type.ts
@@ -1,13 +1,11 @@
 export interface InputFieldBaseProps {
-  value: string;
-  placeholder: string;
-  disabled?: boolean;
   label?: string;
   essential?: boolean;
-  name: string;
 }
 
-export interface InputFieldProps extends InputFieldBaseProps {
+export interface InputFieldProps
+  extends InputFieldBaseProps,
+    React.InputHTMLAttributes<HTMLInputElement> {
   type?: 'text' | 'password' | 'email';
   label?: string;
   errorMessage?: string;
@@ -16,7 +14,9 @@ export interface InputFieldProps extends InputFieldBaseProps {
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
-export interface TextareaFieldProps extends InputFieldBaseProps {
+export interface TextareaFieldProps
+  extends InputFieldBaseProps,
+    React.TextareaHTMLAttributes<HTMLTextAreaElement> {
   size?: 'md' | 'lg';
   height?: string;
   onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;

--- a/types/inputField.type.ts
+++ b/types/inputField.type.ts
@@ -7,7 +7,6 @@ export interface InputFieldProps
   extends InputFieldBaseProps,
     React.InputHTMLAttributes<HTMLInputElement> {
   type?: 'text' | 'password' | 'email';
-  label?: string;
   errorMessage?: string;
   width?: string;
   onClickButton?: () => void;


### PR DESCRIPTION
## 관련 이슈

<!-- 연관된 이슈 번호를 작성해주세요 예 #15 -->

close #124 

## 요약

<!-- 작업 내용에 대해 간단히 설명해주세요 -->
- 로그인에서 '비밀번호를 잊으셨나요?' 클릭 시 임의 모달 만들어 초기화 메일 발송 기능 구현
- 이메일로 연결되는 `/reset-password` 페이지 생성
- 받은 토큰으로 비밀번호 초기화
- 버튼 이전 커밋 반영 내용 추가 (onClick 필수값에서 제외)
- InputField type 변경

## 변경 사항 설명

<!-- 구현한 내용에 대해 자세한 내용을 작성해 주세요 -->
- 로그인 페이지에서 `'비밀번호를 잊으셨나요?'` 클릭 시 모달(임의)이 열리면서 이메일 요청을 합니다. 이메일을 입력하시고 '링크 보내기' 클릭 시 해당 이메일로 비밀번호 초기화 메일이 전달 됩니다
> 꼭 이메일을 받을 수 있는 이메일을 입력 해주세요.
- 받은 메일 링크로 이동하면 토큰값이 담긴 `url`로 `reset-password` 페이지로 이동합니다. (현재는 `localhost:3000` 으로 되어있습니다)
- 변경할 비밀번호를 입력한 후 재설정 버튼을 누르면 변경 완료되었다는 alert과 함께 `/login` 페이지로 이동합니다.

- 추가로 `Buttons` 컴포넌트에 `props`를 이전 PR에서도 수정 했었는데 여기서도 필요할것같아서 미리 `onClick` 필수타입에서 제외 했습니다
- `inputField` 부분에서 새로운 비밀번호는 `autoComplete="new-password"` 값이 들어가야한다고 경고문 뜨길래, 타입 수정했습니다.
> 원래 해놨어야하는건데 제가 js docs에만 작성해두고 추가를 안해뒀더라구요..ㅎㅎ
<!-- 추가적으로 리뷰를 원하는 부분을 알려주세요 -->

## 주의 사항
