### PR TITLE
Feature/issue 134

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
   "eslint.workingDirectories": ["./"],
   "eslint.options": {
-    "overrideConfigFile": ".eslint.config.mjs"
+    "overrideConfigFile": "eslint.config.mjs"
   },
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true,

--- a/app/[teamId]/(index)/GroupHeader.tsx
+++ b/app/[teamId]/(index)/GroupHeader.tsx
@@ -7,16 +7,9 @@ interface GroupHeaderProps {
   // onClick: () => void;
 }
 
-/**
- * @todo
- * ```
- * 헤더의 border 컬러는  `border-primary` 에 `border-opacity-10`입니다. 하지만 `border-primary`는 `hsl`으로 `opacity`를 적용할 수 없는 컬러 값 입니다. 
- 
-그래서 일단 시안과 디자인을 맞추기 위해 `border-[#F8FAFC1A]`를 하드하게 입력했습니다.
-
-차후 커스텀 테마가 추가된다면 수정 하겠습니다.
- * ```
- */
+//TODO 썸네일 이미지 추가
+//TODO 헤더 배경 반응형 색상으로 수정
+//TODO 드롭 다운 컴포넌트 삽입
 export default function GroupHeader({
   name,
   // onClick,

--- a/app/[teamId]/(index)/GroupTaskList.tsx
+++ b/app/[teamId]/(index)/GroupTaskList.tsx
@@ -1,11 +1,7 @@
 import { ITaskListSummary } from '@/types/group.type';
-import { PointColorType } from './GroupTaskListWrapper';
 import KebabDropDown from '@/components/KebabDropDown';
 
-interface GroupTaskListProps {
-  taskList: ITaskListSummary;
-  pointColor: PointColorType;
-}
+import { PointColorType } from './GroupTaskListWrapper';
 
 type IPointColorClasses = {
   [key in PointColorType]: string;
@@ -21,17 +17,28 @@ const POINT_COLOR_CLASSES: IPointColorClasses = {
   yellow: 'bg-p-yellow',
 };
 
+interface GroupTaskListProps {
+  taskList: ITaskListSummary;
+  pointColor: PointColorType;
+  onDelete: (name: string, id: number) => void;
+}
+
 export default function GroupTaskList({
   taskList,
   pointColor,
+  onDelete,
 }: GroupTaskListProps) {
+  const handleClickDelete = () => {
+    onDelete(taskList.name, taskList.id);
+  };
+
   return (
     <div className="flex overflow-hidden rounded-pr-12 transition-all duration-300 hover:scale-[103%] hover:drop-shadow-lg">
       <div className={`w-pr-12 ${POINT_COLOR_CLASSES[pointColor]}`}></div>
       <div className="flex grow items-center justify-between bg-b-secondary px-pr-12 py-pr-10">
         <div>{taskList.name}</div>
         <div>
-          <KebabDropDown onEdit={() => {}} onDelete={() => {}} />
+          <KebabDropDown onEdit={() => {}} onDelete={handleClickDelete} />
         </div>
       </div>
     </div>

--- a/app/[teamId]/(index)/GroupTaskList.tsx
+++ b/app/[teamId]/(index)/GroupTaskList.tsx
@@ -2,6 +2,7 @@ import { ITaskListSummary } from '@/types/group.type';
 import KebabDropDown from '@/components/KebabDropDown';
 
 import { PointColorType } from './GroupTaskListWrapper';
+import { _UpdateTaskListParams } from './page';
 
 type IPointColorClasses = {
   [key in PointColorType]: string;
@@ -20,14 +21,21 @@ const POINT_COLOR_CLASSES: IPointColorClasses = {
 interface GroupTaskListProps {
   taskList: ITaskListSummary;
   pointColor: PointColorType;
+  onEdit: ({ id, name }: _UpdateTaskListParams) => void;
   onDelete: (name: string, id: number) => void;
 }
 
 export default function GroupTaskList({
   taskList,
   pointColor,
+  onEdit,
   onDelete,
 }: GroupTaskListProps) {
+  const handleClickEdit = () => {
+    const name = prompt('목록 명을 입력해주세요');
+    if (name) onEdit({ id: taskList.id, name });
+  };
+
   const handleClickDelete = () => {
     onDelete(taskList.name, taskList.id);
   };
@@ -38,7 +46,10 @@ export default function GroupTaskList({
       <div className="flex grow items-center justify-between bg-b-secondary px-pr-12 py-pr-10">
         <div>{taskList.name}</div>
         <div>
-          <KebabDropDown onEdit={() => {}} onDelete={handleClickDelete} />
+          <KebabDropDown
+            onEdit={handleClickEdit}
+            onDelete={handleClickDelete}
+          />
         </div>
       </div>
     </div>

--- a/app/[teamId]/(index)/GroupTaskList.tsx
+++ b/app/[teamId]/(index)/GroupTaskList.tsx
@@ -2,7 +2,7 @@ import { ITaskListSummary } from '@/types/group.type';
 import KebabDropDown from '@/components/KebabDropDown';
 
 import { PointColorType } from './GroupTaskListWrapper';
-import { _UpdateTaskListParams } from './page';
+import { _DeleteTaskListParams, _UpdateTaskListParams } from './page';
 
 type IPointColorClasses = {
   [key in PointColorType]: string;
@@ -21,8 +21,8 @@ const POINT_COLOR_CLASSES: IPointColorClasses = {
 interface GroupTaskListProps {
   taskList: ITaskListSummary;
   pointColor: PointColorType;
-  onEdit: ({ id, name }: _UpdateTaskListParams) => void;
-  onDelete: (name: string, id: number) => void;
+  onEdit: (params: _UpdateTaskListParams) => void;
+  onDelete: (params: _DeleteTaskListParams) => void;
 }
 
 export default function GroupTaskList({
@@ -37,7 +37,8 @@ export default function GroupTaskList({
   };
 
   const handleClickDelete = () => {
-    onDelete(taskList.name, taskList.id);
+    const flag = confirm(`${taskList.name}을(를) 삭제 하시겠습니다?`);
+    if (flag) onDelete({ id: taskList.id });
   };
 
   return (

--- a/app/[teamId]/(index)/GroupTaskList.tsx
+++ b/app/[teamId]/(index)/GroupTaskList.tsx
@@ -33,7 +33,7 @@ export default function GroupTaskList({
   };
 
   return (
-    <div className="flex overflow-hidden rounded-pr-12 transition-all duration-300 hover:scale-[103%] hover:drop-shadow-lg">
+    <div className="flex overflow-hidden rounded-pr-12 transition-all duration-300 hover:scale-[101%] hover:drop-shadow-lg">
       <div className={`w-pr-12 ${POINT_COLOR_CLASSES[pointColor]}`}></div>
       <div className="flex grow items-center justify-between bg-b-secondary px-pr-12 py-pr-10">
         <div>{taskList.name}</div>

--- a/app/[teamId]/(index)/GroupTaskList.tsx
+++ b/app/[teamId]/(index)/GroupTaskList.tsx
@@ -1,8 +1,8 @@
 import { ITaskListSummary } from '@/types/group.type';
 import KebabDropDown from '@/components/KebabDropDown';
 
+import { _DeleteTaskListParams, _UpdateTaskListParams } from './TeamPage.type';
 import { PointColorType } from './GroupTaskListWrapper';
-import { _DeleteTaskListParams, _UpdateTaskListParams } from './page';
 
 type IPointColorClasses = {
   [key in PointColorType]: string;

--- a/app/[teamId]/(index)/GroupTaskList.tsx
+++ b/app/[teamId]/(index)/GroupTaskList.tsx
@@ -1,0 +1,39 @@
+import { ITaskListSummary } from '@/types/group.type';
+import { PointColorType } from './GroupTaskListWrapper';
+import KebabDropDown from '@/components/KebabDropDown';
+
+interface GroupTaskListProps {
+  taskList: ITaskListSummary;
+  pointColor: PointColorType;
+}
+
+type IPointColorClasses = {
+  [key in PointColorType]: string;
+};
+
+const POINT_COLOR_CLASSES: IPointColorClasses = {
+  purple: 'bg-p-purple',
+  blue: `bg-p-blue`,
+  cyan: 'bg-p-cyan',
+  pink: 'bg-p-pink',
+  rose: 'bg-p-rose',
+  orange: 'bg-p-orange',
+  yellow: 'bg-p-yellow',
+};
+
+export default function GroupTaskList({
+  taskList,
+  pointColor,
+}: GroupTaskListProps) {
+  return (
+    <div className="flex overflow-hidden rounded-pr-12 transition-all duration-300 hover:scale-[103%] hover:drop-shadow-lg">
+      <div className={`w-pr-12 ${POINT_COLOR_CLASSES[pointColor]}`}></div>
+      <div className="flex grow items-center justify-between bg-b-secondary px-pr-12 py-pr-10">
+        <div>{taskList.name}</div>
+        <div>
+          <KebabDropDown onEdit={() => {}} onDelete={() => {}} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/[teamId]/(index)/GroupTaskListWrapper.tsx
+++ b/app/[teamId]/(index)/GroupTaskListWrapper.tsx
@@ -56,7 +56,7 @@ export default function GroupTaskListWrapper({
           className="flex bg-inherit text-brand-primary underline-offset-2 hover:underline"
           onClick={handleClickCreate}
         >
-          <IconPlus />
+          <IconPlus width={17} height={17} />
           <span className="text-14">새로운 목록 추가하기</span>
         </button>
       </div>

--- a/app/[teamId]/(index)/GroupTaskListWrapper.tsx
+++ b/app/[teamId]/(index)/GroupTaskListWrapper.tsx
@@ -2,13 +2,17 @@ import { ITaskListSummary } from '@/types/group.type';
 import IconPlus from '@/public/images/icon-plus.svg';
 
 import GroupTaskList from './GroupTaskList';
-import { _CreateTaskListParams, _UpdateTaskListParams } from './page';
+import {
+  _CreateTaskListParams,
+  _DeleteTaskListParams,
+  _UpdateTaskListParams,
+} from './page';
 
 interface GroupTaskListWrapperProps {
   taskLists: ITaskListSummary[] | null;
   onCreate: (params: _CreateTaskListParams) => void;
-  onEdit: ({ id, name }: _UpdateTaskListParams) => void;
-  onDelete: (id: number) => void;
+  onEdit: (params: _UpdateTaskListParams) => void;
+  onDelete: (params: _DeleteTaskListParams) => void;
 }
 
 export type PointColorType =
@@ -41,13 +45,6 @@ export default function GroupTaskListWrapper({
     if (name) onCreate({ name });
   };
 
-  const handleClickDelete = (name: string, id: number) => {
-    const flag = confirm(`${name}을(를) 삭제 하시겠습니다?`);
-    if (flag) onDelete(id);
-  };
-
-  //TODO 수정하기 핸들러
-
   return (
     <div className="flex flex-col gap-pr-16">
       <div className="flex">
@@ -71,7 +68,7 @@ export default function GroupTaskListWrapper({
           taskList={taskList}
           pointColor={POINT_COLOR[i % POINT_COLOR.length]}
           onEdit={onEdit}
-          onDelete={handleClickDelete}
+          onDelete={onDelete}
         />
       ))}
     </div>

--- a/app/[teamId]/(index)/GroupTaskListWrapper.tsx
+++ b/app/[teamId]/(index)/GroupTaskListWrapper.tsx
@@ -41,7 +41,7 @@ export default function GroupTaskListWrapper({
   onDelete,
 }: GroupTaskListWrapperProps) {
   const handleClickCreate = () => {
-    const name = prompt('목록 명을 입력해주세요', '직박구리');
+    const name = prompt('목록 명을 입력해주세요');
     if (name) onCreate({ name });
   };
 

--- a/app/[teamId]/(index)/GroupTaskListWrapper.tsx
+++ b/app/[teamId]/(index)/GroupTaskListWrapper.tsx
@@ -2,11 +2,11 @@ import { ITaskListSummary } from '@/types/group.type';
 import IconPlus from '@/public/images/icon-plus.svg';
 
 import GroupTaskList from './GroupTaskList';
-import { _UpdateTaskListParams } from './page';
+import { _CreateTaskListParams, _UpdateTaskListParams } from './page';
 
 interface GroupTaskListWrapperProps {
   taskLists: ITaskListSummary[] | null;
-  onCreate: (name: string) => void;
+  onCreate: (params: _CreateTaskListParams) => void;
   onEdit: ({ id, name }: _UpdateTaskListParams) => void;
   onDelete: (id: number) => void;
 }
@@ -38,7 +38,7 @@ export default function GroupTaskListWrapper({
 }: GroupTaskListWrapperProps) {
   const handleClickCreate = () => {
     const name = prompt('목록 명을 입력해주세요', '직박구리');
-    if (name) onCreate(name);
+    if (name) onCreate({ name });
   };
 
   const handleClickDelete = (name: string, id: number) => {

--- a/app/[teamId]/(index)/GroupTaskListWrapper.tsx
+++ b/app/[teamId]/(index)/GroupTaskListWrapper.tsx
@@ -2,10 +2,12 @@ import { ITaskListSummary } from '@/types/group.type';
 import IconPlus from '@/public/images/icon-plus.svg';
 
 import GroupTaskList from './GroupTaskList';
+import { _UpdateTaskListParams } from './page';
 
 interface GroupTaskListWrapperProps {
   taskLists: ITaskListSummary[] | null;
   onCreate: (name: string) => void;
+  onEdit: ({ id, name }: _UpdateTaskListParams) => void;
   onDelete: (id: number) => void;
 }
 
@@ -31,6 +33,7 @@ const POINT_COLOR: PointColorType[] = [
 export default function GroupTaskListWrapper({
   taskLists,
   onCreate,
+  onEdit,
   onDelete,
 }: GroupTaskListWrapperProps) {
   const handleClickCreate = () => {
@@ -42,6 +45,8 @@ export default function GroupTaskListWrapper({
     const flag = confirm(`${name}을(를) 삭제 하시겠습니다?`);
     if (flag) onDelete(id);
   };
+
+  //TODO 수정하기 핸들러
 
   return (
     <div className="flex flex-col gap-pr-16">
@@ -65,6 +70,7 @@ export default function GroupTaskListWrapper({
           key={taskList.id}
           taskList={taskList}
           pointColor={POINT_COLOR[i % POINT_COLOR.length]}
+          onEdit={onEdit}
           onDelete={handleClickDelete}
         />
       ))}

--- a/app/[teamId]/(index)/GroupTaskListWrapper.tsx
+++ b/app/[teamId]/(index)/GroupTaskListWrapper.tsx
@@ -1,0 +1,40 @@
+import { ITaskListSummary } from '@/types/group.type';
+import IconPlus from '@/public/images/icon-plus.svg';
+
+interface GroupTaskListWrapperProps {
+  taskLists: ITaskListSummary[] | null;
+  onCreate: (name: string) => void;
+}
+
+export default function GroupTaskListWrapper({
+  taskLists,
+  onCreate,
+}: GroupTaskListWrapperProps) {
+  const handleClickCreate = () => {
+    const name = prompt('목록 명을 입력해주세요', '직박구리');
+    if (name) onCreate(name);
+  };
+
+  return (
+    <div className="flex flex-col gap-pr-16">
+      <div className="flex">
+        <div className="grow">
+          <span className="text-16m text-t-primary">할 일 목록</span>
+          <span className="text-16m text-t-default">
+            &nbsp;({taskLists?.length || 0}개)
+          </span>
+        </div>
+        <button
+          className="flex bg-inherit text-brand-primary underline-offset-2 hover:underline"
+          onClick={handleClickCreate}
+        >
+          <IconPlus />
+          <span className="text-14">새로운 목록 추가하기</span>
+        </button>
+      </div>
+      {taskLists?.map((taskLists) => (
+        <div key={taskLists.id}>{taskLists.name}</div>
+      ))}
+    </div>
+  );
+}

--- a/app/[teamId]/(index)/GroupTaskListWrapper.tsx
+++ b/app/[teamId]/(index)/GroupTaskListWrapper.tsx
@@ -6,14 +6,7 @@ import {
   _CreateTaskListParams,
   _DeleteTaskListParams,
   _UpdateTaskListParams,
-} from './page';
-
-interface GroupTaskListWrapperProps {
-  taskLists: ITaskListSummary[] | null;
-  onCreate: (params: _CreateTaskListParams) => void;
-  onEdit: (params: _UpdateTaskListParams) => void;
-  onDelete: (params: _DeleteTaskListParams) => void;
-}
+} from './TeamPage.type';
 
 export type PointColorType =
   | 'purple'
@@ -23,6 +16,13 @@ export type PointColorType =
   | 'rose'
   | 'orange'
   | 'yellow';
+
+interface GroupTaskListWrapperProps {
+  taskLists: ITaskListSummary[] | null;
+  onCreate: (params: _CreateTaskListParams) => void;
+  onEdit: (params: _UpdateTaskListParams) => void;
+  onDelete: (params: _DeleteTaskListParams) => void;
+}
 
 const POINT_COLOR: PointColorType[] = [
   'purple',

--- a/app/[teamId]/(index)/GroupTaskListWrapper.tsx
+++ b/app/[teamId]/(index)/GroupTaskListWrapper.tsx
@@ -1,10 +1,12 @@
 import { ITaskListSummary } from '@/types/group.type';
 import IconPlus from '@/public/images/icon-plus.svg';
+
 import GroupTaskList from './GroupTaskList';
 
 interface GroupTaskListWrapperProps {
   taskLists: ITaskListSummary[] | null;
   onCreate: (name: string) => void;
+  onDelete: (id: number) => void;
 }
 
 export type PointColorType =
@@ -29,10 +31,16 @@ const POINT_COLOR: PointColorType[] = [
 export default function GroupTaskListWrapper({
   taskLists,
   onCreate,
+  onDelete,
 }: GroupTaskListWrapperProps) {
   const handleClickCreate = () => {
     const name = prompt('목록 명을 입력해주세요', '직박구리');
     if (name) onCreate(name);
+  };
+
+  const handleClickDelete = (name: string, id: number) => {
+    const flag = confirm(`${name}을(를) 삭제 하시겠습니다?`);
+    if (flag) onDelete(id);
   };
 
   return (
@@ -57,6 +65,7 @@ export default function GroupTaskListWrapper({
           key={taskList.id}
           taskList={taskList}
           pointColor={POINT_COLOR[i % POINT_COLOR.length]}
+          onDelete={handleClickDelete}
         />
       ))}
     </div>

--- a/app/[teamId]/(index)/GroupTaskListWrapper.tsx
+++ b/app/[teamId]/(index)/GroupTaskListWrapper.tsx
@@ -1,10 +1,30 @@
 import { ITaskListSummary } from '@/types/group.type';
 import IconPlus from '@/public/images/icon-plus.svg';
+import GroupTaskList from './GroupTaskList';
 
 interface GroupTaskListWrapperProps {
   taskLists: ITaskListSummary[] | null;
   onCreate: (name: string) => void;
 }
+
+export type PointColorType =
+  | 'purple'
+  | 'blue'
+  | 'cyan'
+  | 'pink'
+  | 'rose'
+  | 'orange'
+  | 'yellow';
+
+const POINT_COLOR: PointColorType[] = [
+  'purple',
+  'blue',
+  'cyan',
+  'pink',
+  'rose',
+  'orange',
+  'yellow',
+];
 
 export default function GroupTaskListWrapper({
   taskLists,
@@ -32,8 +52,12 @@ export default function GroupTaskListWrapper({
           <span className="text-14">새로운 목록 추가하기</span>
         </button>
       </div>
-      {taskLists?.map((taskLists) => (
-        <div key={taskLists.id}>{taskLists.name}</div>
+      {taskLists?.map((taskList, i) => (
+        <GroupTaskList
+          key={taskList.id}
+          taskList={taskList}
+          pointColor={POINT_COLOR[i % POINT_COLOR.length]}
+        />
       ))}
     </div>
   );

--- a/app/[teamId]/(index)/TeamPage.type.ts
+++ b/app/[teamId]/(index)/TeamPage.type.ts
@@ -1,0 +1,18 @@
+interface _CreateTaskListParams {
+  name: string;
+}
+
+interface _UpdateTaskListParams {
+  id: number;
+  name: string;
+}
+
+interface _DeleteTaskListParams {
+  id: number;
+}
+
+export type {
+  _CreateTaskListParams,
+  _UpdateTaskListParams,
+  _DeleteTaskListParams,
+};

--- a/app/[teamId]/(index)/page.tsx
+++ b/app/[teamId]/(index)/page.tsx
@@ -16,6 +16,10 @@ import GroupHeader from './GroupHeader';
 import GroupMemberList from './GroupMemberList';
 import GroupTaskListWrapper from './GroupTaskListWrapper';
 
+export interface _CreateTaskListParams {
+  name: string;
+}
+
 export interface _UpdateTaskListParams {
   id: number;
   name: string;
@@ -26,7 +30,7 @@ export default function TeamPage() {
   const { teamId } = useParams();
   const { group, members, taskLists, reload } = useGroup(Number(teamId));
   const { mutate: onCreate } = useMutation({
-    mutationFn: (name: string) => _createTaskList(name),
+    mutationFn: (params: _CreateTaskListParams) => _createTaskList(params),
     onSuccess: () => reload(),
     onError: (error) => alert(error),
   });
@@ -42,7 +46,7 @@ export default function TeamPage() {
     onError: (error) => alert(error),
   });
 
-  const _createTaskList = (name: string) => {
+  const _createTaskList = ({ name }: _CreateTaskListParams) => {
     if (!group) throw new Error('목록을 생성할 팀이 없습니다');
     return createTaskList({ groupId: group.id, name });
   };

--- a/app/[teamId]/(index)/page.tsx
+++ b/app/[teamId]/(index)/page.tsx
@@ -15,19 +15,11 @@ import {
 import GroupHeader from './GroupHeader';
 import GroupMemberList from './GroupMemberList';
 import GroupTaskListWrapper from './GroupTaskListWrapper';
-
-export interface _CreateTaskListParams {
-  name: string;
-}
-
-export interface _UpdateTaskListParams {
-  id: number;
-  name: string;
-}
-
-export interface _DeleteTaskListParams {
-  id: number;
-}
+import {
+  _CreateTaskListParams,
+  _DeleteTaskListParams,
+  _UpdateTaskListParams,
+} from './TeamPage.type';
 
 export default function TeamPage() {
   useUser(true);

--- a/app/[teamId]/(index)/page.tsx
+++ b/app/[teamId]/(index)/page.tsx
@@ -1,36 +1,55 @@
 'use client';
 
 import { useParams } from 'next/navigation';
-import { useEffect } from 'react';
+import { useMutation } from '@tanstack/react-query';
 
 import Container from '@/components/layout/Container';
 import useUser from '@/hooks/useUser';
 import useGroup from '@/hooks/useGroup';
+import { createTaskList, deleteTaskList } from '@/service/taskList.api';
 
 import GroupHeader from './GroupHeader';
 import GroupMemberList from './GroupMemberList';
+import GroupTaskListWrapper from './GroupTaskListWrapper';
 
 export default function TeamPage() {
-  const { teamId } = useParams();
-  const { group, members, taskLists } = useGroup(Number(teamId));
   useUser(true);
+  const { teamId } = useParams();
+  const { group, members, taskLists, reload } = useGroup(Number(teamId));
+  const { mutate: onCreate } = useMutation({
+    mutationFn: (name: string) => _createTaskList(name),
+    onSuccess: () => reload(),
+    onError: (error) => alert(error),
+  });
+  const { mutate: onDelete } = useMutation({
+    mutationFn: (id: number) => _deleteTaskList(id),
+    onSuccess: () => reload(),
+    onError: (error) => alert(error),
+  });
 
-  useEffect(() => {
-    console.dir(group);
-    console.dir(members);
-    console.dir(taskLists);
-  }, [group, members, taskLists]);
+  const _createTaskList = (name: string) => {
+    if (!group) throw new Error('목록을 생성할 팀이 없습니다');
+    return createTaskList({ groupId: group.id, name });
+  };
+
+  const _deleteTaskList = (taskListId: number) => {
+    if (!group) throw new Error('삭제할 목록의 팀이 없습니다');
+    return deleteTaskList({ groupId: group.id, id: taskListId });
+  };
 
   if (!group) return null;
 
   return (
-    <>
-      <Container>
-        <div className="flex flex-col gap-pr-24 pt-pr-24">
-          <GroupHeader name={group.name} />
-          <GroupMemberList groupId={group.id} members={members} />
-        </div>
-      </Container>
-    </>
+    <Container>
+      <div className="flex flex-col gap-pr-24 pt-pr-24">
+        <GroupHeader name={group.name} />
+        <GroupTaskListWrapper
+          taskLists={taskLists}
+          onCreate={onCreate}
+          onDelete={onDelete}
+        />
+        <GroupMemberList groupId={group.id} members={members} />
+      </div>
+    </Container>
   );
 }

--- a/app/[teamId]/(index)/page.tsx
+++ b/app/[teamId]/(index)/page.tsx
@@ -6,11 +6,20 @@ import { useMutation } from '@tanstack/react-query';
 import Container from '@/components/layout/Container';
 import useUser from '@/hooks/useUser';
 import useGroup from '@/hooks/useGroup';
-import { createTaskList, deleteTaskList } from '@/service/taskList.api';
+import {
+  createTaskList,
+  deleteTaskList,
+  updateTaskList,
+} from '@/service/taskList.api';
 
 import GroupHeader from './GroupHeader';
 import GroupMemberList from './GroupMemberList';
 import GroupTaskListWrapper from './GroupTaskListWrapper';
+
+export interface _UpdateTaskListParams {
+  id: number;
+  name: string;
+}
 
 export default function TeamPage() {
   useUser(true);
@@ -18,6 +27,12 @@ export default function TeamPage() {
   const { group, members, taskLists, reload } = useGroup(Number(teamId));
   const { mutate: onCreate } = useMutation({
     mutationFn: (name: string) => _createTaskList(name),
+    onSuccess: () => reload(),
+    onError: (error) => alert(error),
+  });
+  const { mutate: onEdit } = useMutation({
+    mutationFn: ({ id, name }: _UpdateTaskListParams) =>
+      _updateTaskList({ id, name }),
     onSuccess: () => reload(),
     onError: (error) => alert(error),
   });
@@ -30,6 +45,11 @@ export default function TeamPage() {
   const _createTaskList = (name: string) => {
     if (!group) throw new Error('목록을 생성할 팀이 없습니다');
     return createTaskList({ groupId: group.id, name });
+  };
+
+  const _updateTaskList = ({ id, name }: _UpdateTaskListParams) => {
+    if (!group) throw new Error('수정할 목록의 팀이 없습니다');
+    return updateTaskList({ groupId: group.id, id, name });
   };
 
   const _deleteTaskList = (taskListId: number) => {
@@ -46,6 +66,7 @@ export default function TeamPage() {
         <GroupTaskListWrapper
           taskLists={taskLists}
           onCreate={onCreate}
+          onEdit={onEdit}
           onDelete={onDelete}
         />
         <GroupMemberList groupId={group.id} members={members} />

--- a/app/[teamId]/(index)/page.tsx
+++ b/app/[teamId]/(index)/page.tsx
@@ -25,6 +25,10 @@ export interface _UpdateTaskListParams {
   name: string;
 }
 
+export interface _DeleteTaskListParams {
+  id: number;
+}
+
 export default function TeamPage() {
   useUser(true);
   const { teamId } = useParams();
@@ -35,30 +39,29 @@ export default function TeamPage() {
     onError: (error) => alert(error),
   });
   const { mutate: onEdit } = useMutation({
-    mutationFn: ({ id, name }: _UpdateTaskListParams) =>
-      _updateTaskList({ id, name }),
+    mutationFn: (params: _UpdateTaskListParams) => _updateTaskList(params),
     onSuccess: () => reload(),
     onError: (error) => alert(error),
   });
   const { mutate: onDelete } = useMutation({
-    mutationFn: (id: number) => _deleteTaskList(id),
+    mutationFn: (params: _DeleteTaskListParams) => _deleteTaskList(params),
     onSuccess: () => reload(),
     onError: (error) => alert(error),
   });
 
-  const _createTaskList = ({ name }: _CreateTaskListParams) => {
+  const _createTaskList = (params: _CreateTaskListParams) => {
     if (!group) throw new Error('목록을 생성할 팀이 없습니다');
-    return createTaskList({ groupId: group.id, name });
+    return createTaskList({ groupId: group.id, ...params });
   };
 
-  const _updateTaskList = ({ id, name }: _UpdateTaskListParams) => {
+  const _updateTaskList = (params: _UpdateTaskListParams) => {
     if (!group) throw new Error('수정할 목록의 팀이 없습니다');
-    return updateTaskList({ groupId: group.id, id, name });
+    return updateTaskList({ groupId: group.id, ...params });
   };
 
-  const _deleteTaskList = (taskListId: number) => {
+  const _deleteTaskList = (params: _DeleteTaskListParams) => {
     if (!group) throw new Error('삭제할 목록의 팀이 없습니다');
-    return deleteTaskList({ groupId: group.id, id: taskListId });
+    return deleteTaskList({ groupId: group.id, ...params });
   };
 
   if (!group) return null;

--- a/components/NavigationGroupDropdown/DropdownAddGroup.tsx
+++ b/components/NavigationGroupDropdown/DropdownAddGroup.tsx
@@ -1,6 +1,6 @@
 import { DropdownMenuItem } from '@/components/ui/dropdown-menu';
 import { Button } from '@/components/ui/button';
-import Plus from '@/public/images/icon-plus.svg';
+import IconPlus from '@/public/images/icon-plus.svg';
 
 /**
  * 그룹 추가 버튼
@@ -10,7 +10,12 @@ export default function DropdownAddGroup() {
   return (
     <DropdownMenuItem asChild>
       <Button className="mt-pr-16 w-full rounded-lg border border-slate-50 bg-inherit">
-        <Plus className="text-t-primary" width={17} height={17} />
+        <IconPlus
+          className="text-t-primary"
+          height={17}
+          width={17}
+          stroke="#F8FAFC"
+        />
         <span className="text-t-primary">팀 추가하기</span>
       </Button>
     </DropdownMenuItem>

--- a/stores/useGroup.stroe.ts
+++ b/stores/useGroup.stroe.ts
@@ -1,14 +1,14 @@
-import { IGroupDetail, IMember, TaskListSummary } from '@/types/group.type';
+import { IGroupDetail, IMember, ITaskListSummary } from '@/types/group.type';
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
 interface IUseGroupStore {
   group: IGroupDetail | null;
   members: IMember[] | null;
-  taskLists: TaskListSummary[] | null;
+  taskLists: ITaskListSummary[] | null;
   setGroup: (group: IGroupDetail | null) => void;
   setMembers: (members: IMember[] | null) => void;
-  setTaskLists: (taskLists: TaskListSummary[] | null) => void;
+  setTaskLists: (taskLists: ITaskListSummary[] | null) => void;
   clearStore: () => void;
 }
 

--- a/styles/base.css
+++ b/styles/base.css
@@ -14,13 +14,13 @@
     --brand-gradient: linear-gradient(90deg, #10b981 0%, #a3e635 100%);
 
     /* point */
-    --p-purple: #a855f7;
-    --p-blue: #3b82f6;
-    --p-cyan: #06b6d4;
-    --p-pink: #ec4899;
-    --p-rose: #f43f5e;
-    --p-orange: #f97316;
-    --p-yellow: #eab308;
+    --point-purple: #a855f7;
+    --point-blue: #3b82f6;
+    --point-cyan: #06b6d4;
+    --point-pink: #ec4899;
+    --point-rose: #f43f5e;
+    --point-orange: #f97316;
+    --point-yellow: #eab308;
 
     /* background */
     --b-primary-dark: #0f172a;

--- a/types/group.type.ts
+++ b/types/group.type.ts
@@ -21,7 +21,7 @@ interface IMember {
   userId: number;
 }
 
-interface TaskListSummary {
+interface ITaskListSummary {
   displayIndex: number;
   groupId: number;
   updatedAt: string;
@@ -33,7 +33,7 @@ interface TaskListSummary {
 
 interface IGroupDetail extends IGroup {
   members: IMember[];
-  taskLists: TaskListSummary[];
+  taskLists: ITaskListSummary[];
 }
 
 interface GetGroupParams {
@@ -97,7 +97,7 @@ interface GetTasksInGroupParams {
 export type {
   IMember,
   IGroup,
-  TaskListSummary,
+  ITaskListSummary,
   IGroupDetail,
   GetGroupParams,
   UpdateGroupParams,


### PR DESCRIPTION
## 관련 이슈

close #134 

## 변경 사항 설명

### 할 일 목록 컴포넌트 구현

팀 페이지의 할 일 목록 컴포넌트를 구현했습니다.

해당 컴포넌트는 다음 기능을 포함합니다.

**새로운 목록 추가하기**

새로운 할 일 목록을 추가할 수 있습니다.

브라우저의 기본 프롬프트를 활용해 목록명을 입력한 후 생성할 수 있습니다.

![image](https://github.com/user-attachments/assets/0d334cb6-2a42-45fe-b536-ee023638c5b6)

해당 기능은 차후 공용 모달을 활용해 목록명을 입력하도록 수정할 예정입니다.

 할 일 목록 수정 및 삭제하기

할 일 목록의 케밥 드롭다운을 활용해 수정 및 삭제를 할 수 있습니다.

![image](https://github.com/user-attachments/assets/7bf4915f-f8f4-4db4-90cf-557bcf8f2ce3)

해당 기능도 차후 공용 모달을 적용할 예정입니다.


**현재 해당 컴포넌트에는 진행도를 보여주는 라벨이 붙어 있지 않습니다.**

| 시안 | PR |
|---|---|
|![image](https://github.com/user-attachments/assets/41aa88a7-89c3-4f08-917c-83f1a7a9700b)|![image](https://github.com/user-attachments/assets/d66fdcdb-5435-45de-891e-ec5746b6706e)|

원래는 시안과 동일하게 라벨을 붙여 PR을 올릴 예정이었지만, 백엔드 이슈로 인해 라벨을 렌더링하기 까지의 로직이 매우 길어졌습니다.

그래서 컴포넌트 마크업에 관한 커밋과 라벨 마크업에 관한 커밋을 서로 다른 브랜치로 분할 했고,

컴포넌트 마크업에 관한 브랜치를 먼저 PR했습니다.

해당 PR이 merge 되는 대로 라벨 마크업 브랜치를 PR 하겠습니다.

### 팀 페이지 렌더링

지금까지 구현된 컴포넌트들만 취합해 팀 페이지를 구성했습니다.

![image](https://github.com/user-attachments/assets/d776fb3d-b19d-4c1b-9a8d-31ceb11aef8e)

멤버 목록의 경우 멤버 초대 기능이 아직 구현되지 않아 테스트를 위한 스토리 북을 따로 만들어 두었지만,

다른 기능들의 경우는 모두 팀 페이지에서 테스트 가능하기 때문에 따로 스토리 북을 만들지 않았습니다.

### setting.json 오타 수정

eslint에서 자꾸 `.eslint.config.mjs`를 찾을 수 없다는 오류가 발생해서 원인을 찾아보니

setting.json에 오타가 있었습니다.
``` json
 "overrideConfigFile": ".eslint.config.mjs"
```

그래서 이를 다음과 같이 수정했습니다.
``` json
 "overrideConfigFile": "eslint.config.mjs"
```
수정 이후에는 eslint 오류가 발생하지 않습니다.

## 주의 사항

팀 페이지 헤더의 경우 라이트 테마 디자인이 적용되어 있지 않습니다. 해당 이슈는 중요도가 낮다고 판단해 작업을 조금 뒤로 미루었습니다.

팀 헤더 드롭 다운도 헤더의 라이트 테마를 추가하기 위한 이슈에서 같이 작업하겠습니다.