### PR TITLE
#150 프로필 컴포넌트 에러메세지 및 라벨 추가

### DIFF
--- a/components/Profile/Profile.tsx
+++ b/components/Profile/Profile.tsx
@@ -3,6 +3,8 @@ import classNames from 'classnames';
 
 import IconProfile from './IconProfile';
 import IconEdit from './IconEdit';
+import InputLabel from '../InputField/InputLabel';
+import ErrorMessage from '../InputField/ErrorMessage';
 
 // 타입 정의
 type Variant = 'member' | 'group';
@@ -10,9 +12,11 @@ type Variant = 'member' | 'group';
 interface ProfileProps {
   image?: string | null;
   variant: Variant;
+  label?: string;
   isEdit?: boolean;
   editSize?: number;
   profileSize?: number;
+  errorMessage?: string;
   onSelectFile?: (e: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
@@ -20,18 +24,22 @@ interface ProfileProps {
  * 프로필 컴포넌트
  * @param variant 프로필 타입 (member, group)
  * @param preview 미리보기 이미지 URL
+ * @param label 레이블
  * @param image 프로필 이미지 URL
  * @param profileSize 프로필 이미지 크기 (기본값: 64)
  * @param isEdit 수정 버튼 표시 여부
  * @param editSize 수정 버튼 크기 클래스 (기본값: 24)
+ * @param errorMessage 에러 메시지
  * @param onSelectFile 파일 선택 시 호출될 콜백 함수
  */
 export default function Profile({
   image,
   variant,
+  label,
   profileSize = 64,
   editSize = 24,
   isEdit = false,
+  errorMessage,
   onSelectFile,
 }: ProfileProps) {
   // 프로필 이미지 또는 기본 아이콘
@@ -49,41 +57,45 @@ export default function Profile({
     );
 
   return (
-    <fieldset className="relative size-fit select-none">
-      <label
-        htmlFor={isEdit ? 'edit' : ''}
-        aria-label={`${variant} 프로필 이미지${isEdit && ' 수정'}`}
-        className={classNames(
-          'relative',
-          isEdit && 'cursor-pointer hover:opacity-70',
-        )}
-      >
-        <div
+    <div>
+      <fieldset className="relative size-fit select-none">
+        {label && <InputLabel label={label} />}
+        <label
+          htmlFor={isEdit ? 'edit' : ''}
+          aria-label={`${variant} 프로필 이미지${isEdit && ' 수정'}`}
           className={classNames(
-            'relative overflow-hidden rounded-full',
-            profileSize > 32 ? 'border-2' : 'border',
+            'relative',
+            isEdit && 'cursor-pointer hover:opacity-70',
           )}
-          style={{ width: profileSize, height: profileSize }}
         >
-          {renderProfileImage()}
-        </div>
+          <div
+            className={classNames(
+              'flex items-center justify-center overflow-hidden rounded-full',
+              profileSize > 32 ? 'border-2' : 'border',
+            )}
+            style={{ width: profileSize, height: profileSize }}
+          >
+            {renderProfileImage()}
+          </div>
 
+          {isEdit && (
+            <IconEdit
+              className="absolute -bottom-pr-4 -right-pr-4"
+              size={editSize}
+            />
+          )}
+        </label>
         {isEdit && (
-          <IconEdit
-            className="absolute -bottom-pr-4 -right-pr-4"
-            size={editSize}
+          <input
+            id="edit"
+            type="file"
+            className="hidden"
+            onChange={onSelectFile}
+            accept="image/jpeg, image/png, image/webp, image/jpg"
           />
         )}
-      </label>
-      {isEdit && (
-        <input
-          id="edit"
-          type="file"
-          className="hidden"
-          onChange={onSelectFile}
-          accept="image/jpeg, image/png, image/webp, image/jpg"
-        />
-      )}
-    </fieldset>
+      </fieldset>
+      {errorMessage && <ErrorMessage message={errorMessage} />}
+    </div>
   );
 }

--- a/components/Profile/Profile.tsx
+++ b/components/Profile/Profile.tsx
@@ -1,10 +1,11 @@
 import Image from 'next/image';
 import classNames from 'classnames';
 
+import InputLabel from '@/components/InputField/InputLabel';
+import ErrorMessage from '@/components/InputField/ErrorMessage';
+
 import IconProfile from './IconProfile';
 import IconEdit from './IconEdit';
-import InputLabel from '../InputField/InputLabel';
-import ErrorMessage from '../InputField/ErrorMessage';
 
 // 타입 정의
 type Variant = 'member' | 'group';

--- a/hooks/useFileHandler.ts
+++ b/hooks/useFileHandler.ts
@@ -20,6 +20,7 @@ export function useFileHandler({ onFileChange }: UseFileHandlerProps) {
         // 파일 크기 검증
         if (file.size > MAX_SIZE_BYTES) {
           setError('파일 크기는 10MB 이하여야 합니다.');
+          setPreview(undefined);
           return;
         }
 

--- a/hooks/useForm.ts
+++ b/hooks/useForm.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import { validateField } from '@/utils/validation';
 import { useFileHandler } from '@/hooks/useFileHandler';
@@ -65,6 +65,14 @@ const useForm = <T extends Record<string, FormValue>>(initialValues: T) => {
       }));
     },
   });
+
+  // 파일 에러 메시지를 폼 에러 메시지에 추가
+  useEffect(() => {
+    setErrorMessage((prevErr) => ({
+      ...prevErr,
+      image: fileError,
+    }));
+  }, [fileError]);
 
   // 초기화 함수
   const resetForm = useCallback(


### PR DESCRIPTION
## 관련 이슈

<!-- 연관된 이슈 번호를 작성해주세요 예 #15 -->

close #150 

## 요약

<!-- 작업 내용에 대해 간단히 설명해주세요 -->
- 프로필 컴포넌트 label 컴포넌트 추가 및 props 추가
- useFilehandler 프리뷰 초기화
- useForm내부에서 파일 에러메세지를 폼 에러메세지에 추가

## 변경 사항 설명

<!-- 구현한 내용에 대해 자세한 내용을 작성해 주세요 -->
- InputField 처럼 동일한 label이 필요할 것 같아서 프로필 컴포넌트에도 추가를 했는데 fieldset안에 label이 두개가 있어도 되는지는 모르겠습니다
- 프로필 컴포넌트 디폴트 이미지 일때 bg가 살짝 틀어지는 부분이 있어서 해당 스타일 수정하여, 틀어지지않도록 했습니다
- file input에 대해서 파일 크기에 대한 에러 메세지 노출되도록 추가 하였습니다
- useForm에서 파일 input에 변화가 있을때, 지정된 용량이 넘어가면 프리뷰는 보여주지않고 하단에 에러메세지를 띄웁니다.
<!-- 추가적으로 리뷰를 원하는 부분을 알려주세요 -->

## 주의 사항
