### PR TITLE
새로고침 시 리다이렉트 되는 문제를 해결

### DIFF
--- a/hooks/useUser.ts
+++ b/hooks/useUser.ts
@@ -88,10 +88,10 @@ const useUser = (required?: boolean) => {
 
   useEffect(() => {
     if (!required) return;
-    if (!token || (!user && !isPending)) {
+    if (!token || (!data && !isPending)) {
       router.push('/');
     }
-  }, [required, token, user, isPending, router]);
+  }, [required, token, data, isPending, router]);
 
   return {
     isAuthenticated: !!token,


### PR DESCRIPTION
## 관련 이슈

close #173 

## 변경 사항 설명

### 리다이렉트 문제 해결

원래는 `store`에 저장된 `user`와 `useQuery`의 `isPending`을 활용해 리다이렉트 여부를 판단합니다.

하지만 `store`의 `user`와 `useQuery`의 `isPending`은 변경되는 타이밍이 다릅니다.

때문에 `useQuery`로 `data`를 받아와서 `isPending`은 `true`에서 `false`로 변했지만 `user`는 `null`인 타이밍이 존재했습니다.

이 타이밍에 `useUser`가 페이지를 `/`로 리다이렉트 시키는게 에러의 원인이었습니다.

그래서 변경된 코드에서는 `user`를 대신해 `data`를 활용해 리다이렉트 여부를 판단하도록 수정했습니다.

`user`와 `data`는 같은 데이터이므로 기능적인 차이는 발생하지 않을 거 같습니다.