### PR TITLE
#170 구글로그인 및 카카오로그인 기능 구현

### DIFF
--- a/app/(auth)/layout.tsx
+++ b/app/(auth)/layout.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { usePathname } from 'next/navigation';
+import { useSession } from 'next-auth/react';
 
 import Container from '@/components/layout/Container';
 import OauthForm from '@/components/OauthForm';
@@ -12,6 +13,8 @@ interface ILayoutProps {
 export default function Layout({ children }: ILayoutProps) {
   const pathName = usePathname();
   const currentPath = pathName.split('/').pop();
+
+  const { status } = useSession();
 
   const pageTitles: Record<string, string> = {
     login: '로그인',
@@ -33,9 +36,11 @@ export default function Layout({ children }: ILayoutProps) {
       <div className="mx-auto w-pr-460 mo:w-full">
         {children}
         <div className="mt-pr-48 mo:mt-pr-25">
-          {currentPath && ['login', 'signup'].includes(currentPath) && (
-            <OauthForm type={currentPath as 'login' | 'signup'} />
-          )}
+          {currentPath &&
+            ['login', 'signup'].includes(currentPath) &&
+            status !== 'loading' && (
+              <OauthForm type={currentPath as 'login' | 'signup'} />
+            )}
         </div>
       </div>
     </Container>

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, MouseEvent, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { useMutation } from '@tanstack/react-query';
+import { useSession } from 'next-auth/react';
 
 import { signIn } from '@/service/auth.api';
 import useForm from '@/hooks/useForm';
@@ -12,6 +13,7 @@ import InputField from '@/components/InputField/InputField';
 import Buttons from '@/components/Buttons';
 import useModalStore from '@/stores/modalStore';
 import ResetPassword from '@/components/modal/ResetPassword';
+import AuthLoading from '@/components/AuthLoading';
 
 function LoginPage() {
   const { formData, handleInputChange, errorMessage } = useForm({
@@ -23,9 +25,12 @@ function LoginPage() {
   const { user, reload, isAuthenticated } = useUser();
   const { openModal } = useModalStore();
 
-  // submit 후 로그인 에러 메시지
+  const { status } = useSession();
+
+  // STUB submit 후 로그인 에러 메시지
   const [hasLoginError, setHasLoginError] = useState('');
 
+  // STUB 일반 로그인 api mutate
   const { mutateAsync: postLogin, isPending: isLogin } = useMutation({
     mutationFn: signIn,
     onSuccess: (res) => {
@@ -36,26 +41,27 @@ function LoginPage() {
     onError: () => setHasLoginError('이메일 혹은 비밀번호를 확인해주세요.'),
   });
 
-  // 로그인 버튼 클릭 시
+  // STUB 로그인 버튼 클릭 시
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
     postLogin(formData);
   };
 
-  // 비밀번호 찾기 모달 오픈
+  // STUB 비밀번호 찾기 모달 오픈
   const handleOpenResetPassword = (e: MouseEvent) => {
     e.preventDefault();
     openModal(<ResetPassword />);
   };
 
-  // 로그인 성공 시
+  // STUB 로그인 성공 시
   useEffect(() => {
     if (user) alert('로그인 성공!');
   }, [user]);
 
   useEffect(() => {
     if (isAuthenticated) {
+      // STUB 로그인 후 가입된 그룹이 있을 때, 첫 번째 그룹으로 이동
       if (user && user.memberships.length > 0) {
         route.push(`/${user.memberships[0].groupId}`);
       } else {
@@ -66,7 +72,9 @@ function LoginPage() {
     }
   }, [user, route, isAuthenticated]);
 
-  // 로그인 상태가 아닐 때
+  if (status === 'loading') return <AuthLoading />;
+
+  // STUB 로그인 상태가 아닐 때
   return (
     <>
       <form onSubmit={handleSubmit}>

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -28,10 +28,10 @@ function LoginPage() {
 
   const { mutateAsync: postLogin, isPending: isLogin } = useMutation({
     mutationFn: signIn,
-    onSuccess: () => {
+    onSuccess: (res) => {
       reload();
-      alert('로그인이 완료 되었습니다.');
-      console.log('로그인 완료');
+      alert('(login)로그인이 완료 되었습니다.');
+      console.log('로그인 완료 : ', res);
     },
     onError: () => setHasLoginError('이메일 혹은 비밀번호를 확인해주세요.'),
   });

--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,24 +1,52 @@
 import NextAuth, { NextAuthOptions } from 'next-auth';
 import GoogleProvider from 'next-auth/providers/google';
+import KakaoProvider from 'next-auth/providers/kakao';
 
 export const authOptions: NextAuthOptions = {
+  // TODO 디버그 모드(실제 배포 시 false로 변경)
+  debug: true,
   providers: [
     GoogleProvider({
       clientId: process.env.GOOGLE_CLIENT_ID || '',
       clientSecret: process.env.GOOGLE_CLIENT_SECRET || '',
     }),
+    KakaoProvider({
+      clientId: process.env.NEXT_PUBLIC_KAKAO_CLIENT_ID || '',
+      clientSecret: process.env.KAKAO_CLIENT_SECRET || '',
+    }),
   ],
   callbacks: {
     async jwt({ token, account }) {
       if (account) {
-        token.idToken = account.id_token; // Google ID 토큰 저장(로그인 시 필요)
-        token.accessToken = account.access_token; // Google Access Token 저장(탈퇴 시 필요)
+        // STUB 구글 토큰 저장
+        if (account.provider === 'google') {
+          token.googleIdToken = account.id_token;
+          token.googleAccessToken = account.access_token;
+        }
+        // STUB 카카오 토큰 저장
+        if (account.provider === 'kakao') {
+          token.kakaoAccessToken = account.access_token;
+          token.kakaoRefreshToken = account.refresh_token;
+          token.id = account.providerAccountId;
+        }
       }
       return token;
     },
     async session({ session, token }) {
-      session.idToken = token.idToken as string; // 세션에 ID 토큰 추가(로그인 시 필요)
-      session.accessToken = token.accessToken as string; // 세션에 Access Token 추가(탈퇴 시 필요)
+      // STUB 세션에 구글 토큰 저장
+      if (token.googleIdToken) {
+        session.googleIdToken = token.googleIdToken as string;
+        session.googleAccessToken = token.googleAccessToken as string;
+      }
+      // STUB 세션에 카카오 토큰 저장
+      if (token.kakaoAccessToken) {
+        session.kakao = {
+          accessToken: token.kakaoAccessToken as string,
+          refreshToken: token.kakaoRefreshToken as string,
+          id: token.id as number,
+        };
+      }
+
       return session;
     },
   },

--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -40,11 +40,8 @@ export const authOptions: NextAuthOptions = {
       }
       // STUB 세션에 카카오 토큰 저장
       if (token.kakaoAccessToken) {
-        session.kakao = {
-          accessToken: token.kakaoAccessToken as string,
-          refreshToken: token.kakaoRefreshToken as string,
-          id: token.id as number,
-        };
+        session.kakaoAccessToken = token.kakaoAccessToken as string;
+        session.id = token.id as number;
       }
 
       return session;

--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,28 @@
+import NextAuth, { NextAuthOptions } from 'next-auth';
+import GoogleProvider from 'next-auth/providers/google';
+
+export const authOptions: NextAuthOptions = {
+  providers: [
+    GoogleProvider({
+      clientId: process.env.GOOGLE_CLIENT_ID || '',
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET || '',
+    }),
+  ],
+  callbacks: {
+    async jwt({ token, account }) {
+      if (account) {
+        token.idToken = account.id_token; // Google ID 토큰 저장(로그인 시 필요)
+        token.accessToken = account.access_token; // Google Access Token 저장(탈퇴 시 필요)
+      }
+      return token;
+    },
+    async session({ session, token }) {
+      session.idToken = token.idToken as string; // 세션에 ID 토큰 추가(로그인 시 필요)
+      session.accessToken = token.accessToken as string; // 세션에 Access Token 추가(탈퇴 시 필요)
+      return session;
+    },
+  },
+};
+
+const handler = NextAuth(authOptions);
+export { handler as GET, handler as POST };

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -15,6 +15,7 @@ import { SidebarProvider } from '@/components/ui/sidebar';
 import Headers from '@/components/layout/Header/Headers';
 import { DeviceTypeProvider } from '@/contexts/DeviceTypeContext';
 import Modal from '@/components/modal/Modal';
+import AuthProvider from '@/contexts/AuthProvider';
 
 const queryClient = new QueryClient();
 export default function RootLayout({
@@ -33,12 +34,14 @@ export default function RootLayout({
             disableTransitionOnChange
           >
             <QueryClientProvider client={queryClient}>
-              <SidebarProvider defaultOpen={false}>
-                <Headers />
-                <DarkmodeToggle />
-                <Modal />
-                {children}
-              </SidebarProvider>
+              <AuthProvider>
+                <SidebarProvider defaultOpen={false}>
+                  <Headers />
+                  <DarkmodeToggle />
+                  <Modal />
+                  {children}
+                </SidebarProvider>
+              </AuthProvider>
               <ReactQueryDevtools initialIsOpen={false} />
             </QueryClientProvider>
           </ThemeProvider>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,8 @@
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+import { SessionProvider } from 'next-auth/react';
+import { Session } from 'next-auth';
 
 import '@/styles/fonts.css';
 import '@/styles/globals.css';
@@ -15,13 +17,14 @@ import { SidebarProvider } from '@/components/ui/sidebar';
 import Headers from '@/components/layout/Header/Headers';
 import { DeviceTypeProvider } from '@/contexts/DeviceTypeContext';
 import Modal from '@/components/modal/Modal';
-import AuthProvider from '@/contexts/AuthProvider';
 
 const queryClient = new QueryClient();
 export default function RootLayout({
   children,
+  session,
 }: Readonly<{
   children: React.ReactNode;
+  session?: Session;
 }>) {
   return (
     <html lang="ko">
@@ -34,14 +37,14 @@ export default function RootLayout({
             disableTransitionOnChange
           >
             <QueryClientProvider client={queryClient}>
-              <AuthProvider>
+              <SessionProvider session={session}>
                 <SidebarProvider defaultOpen={false}>
                   <Headers />
                   <DarkmodeToggle />
                   <Modal />
                   {children}
                 </SidebarProvider>
-              </AuthProvider>
+              </SessionProvider>
               <ReactQueryDevtools initialIsOpen={false} />
             </QueryClientProvider>
           </ThemeProvider>

--- a/components/AuthLoading.tsx
+++ b/components/AuthLoading.tsx
@@ -1,0 +1,15 @@
+import { Loader2 } from 'lucide-react';
+
+/**
+ * 인증 로딩 컴포넌트
+ */
+export default function AuthLoading() {
+  return (
+    <div className="flex items-center justify-center">
+      <div className="flex flex-col items-center gap-pr-10">
+        <Loader2 className="animate-spin" />
+        <p className="text-24b">잠시만 기다려주세요...</p>
+      </div>
+    </div>
+  );
+}

--- a/components/OauthForm.tsx
+++ b/components/OauthForm.tsx
@@ -1,4 +1,62 @@
+import { useMutation } from '@tanstack/react-query';
+import { signIn, useSession } from 'next-auth/react';
+import { useEffect } from 'react';
+
+import { signInProvider } from '@/service/auth.api';
+import useUser from '@/hooks/useUser';
+// import useForm from '@/hooks/useForm';
+
 export default function OauthForm({ type }: { type: 'login' | 'signup' }) {
+  const session = useSession();
+
+  const { user, reload } = useUser();
+
+  console.log('🔹 세션 상태:', session);
+
+  const { mutateAsync: postOauthLogin } = useMutation({
+    mutationFn: signInProvider,
+    onSuccess: (res) => {
+      alert('(oauth)로그인이 완료 되었습니다.');
+      reload();
+      console.log('로그인 완료 : ', res);
+    },
+    onError: (err) => {
+      console.error('로그인 실패:', err);
+      alert('로그인 중 문제가 발생했습니다.');
+    },
+  });
+
+  const handleGoogleSubmit = async () => {
+    // 구글 로그인
+    const result = await signIn('google', {
+      prompt: 'select_account',
+      redirect: true,
+    });
+
+    if (result?.error) {
+      console.error('Google 로그인 실패:', result.error);
+    } else {
+      console.log('Google 로그인 성공:', result);
+    }
+  };
+
+  useEffect(() => {
+    // 로그인 상태이고, 세션에 idToken이 존재하면
+    if (!user && session.status === 'authenticated' && session.data?.idToken) {
+      // 구글 로그인 데이터
+      const googleFormData = {
+        provider: 'GOOGLE',
+        state: 'authenticated',
+        redirectUri: 'http://localhost:3000/api/auth/callback/google',
+        token: session.data?.idToken || '',
+      };
+      console.log('🔹 Google 인증 완료, 백엔드 로그인 실행 중...');
+
+      // 백엔드 로그인
+      postOauthLogin(googleFormData);
+    }
+  }, [session.status, session.data?.idToken, postOauthLogin, user]);
+
   return (
     <>
       <div className="mb-pr-16 flex items-center justify-center gap-pr-24">
@@ -10,12 +68,11 @@ export default function OauthForm({ type }: { type: 'login' | 'signup' }) {
         <p className="flex-1">
           {type === 'login' ? '간편 로그인하기' : '간편 회원가입하기'}
         </p>
-        <button
-          className="icon_oauth-google"
-          onClick={() => console.log('구글 로그인 클릭')}
-        >
+
+        <button className="icon_oauth-google" onClick={handleGoogleSubmit}>
           <span className="sr-only">구글 로그인</span>
         </button>
+
         <button
           className="icon_oauth-kakao"
           onClick={() => console.log('카카오 로그인 클릭')}

--- a/components/layout/Header/Headers.tsx
+++ b/components/layout/Header/Headers.tsx
@@ -13,6 +13,7 @@ import SideNavigation from '@/components/SideNavigation/SideNavigation';
 import useUser from '@/hooks/useUser';
 import { IGroup } from '@/types/group.type';
 import DropDown from '@/components/DropDown';
+import { logoutKakaoAccessStorage } from '@/lib/kakaoStorage';
 
 import Profile from './Profile';
 import Logo from './Logo';
@@ -29,7 +30,11 @@ function Headers() {
     const flag = confirm('로그아웃 하시겠습니까?');
     if (flag) {
       clear();
-      signOut({ redirect: false });
+
+      // STUB 세션 로그아웃
+      signOut();
+      logoutKakaoAccessStorage();
+
       alert('로그아웃 되었습니다.');
     }
   }, [clear]);
@@ -44,7 +49,7 @@ function Headers() {
         onClick: logout,
       },
     ],
-    [clear],
+    [logout],
   );
 
   useEffect(() => {
@@ -55,7 +60,7 @@ function Headers() {
     const group = groups.find((group) => group.id === groupId);
     if (group) setCurrentGroup(group);
     else router.push('/');
-  }, [groupId, groups, isPending]);
+  }, [groupId, groups, isPending, router]);
 
   return (
     <header className="fixed z-40 flex w-full items-center border-b bg-b-secondary transition-all">

--- a/components/layout/Header/Headers.tsx
+++ b/components/layout/Header/Headers.tsx
@@ -3,6 +3,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
+import { signOut } from 'next-auth/react';
 
 import NavigationGroupDropdown from '@/components/NavigationGroupDropdown/NavigationGroupDropdown';
 import { Button } from '@/components/ui/button';
@@ -28,6 +29,7 @@ function Headers() {
     const flag = confirm('로그아웃 하시겠습니까?');
     if (flag) {
       clear();
+      signOut({ redirect: false });
       alert('로그아웃 되었습니다.');
     }
   }, [clear]);

--- a/components/layout/Header/Headers.tsx
+++ b/components/layout/Header/Headers.tsx
@@ -13,7 +13,7 @@ import SideNavigation from '@/components/SideNavigation/SideNavigation';
 import useUser from '@/hooks/useUser';
 import { IGroup } from '@/types/group.type';
 import DropDown from '@/components/DropDown';
-import { logoutKakaoAccessStorage } from '@/lib/kakaoStorage';
+import { removeLoginProcessed } from '@/lib/kakaoStorage';
 
 import Profile from './Profile';
 import Logo from './Logo';
@@ -31,9 +31,9 @@ function Headers() {
     if (flag) {
       clear();
 
-      // STUB 세션 로그아웃
+      // // STUB 세션 로그아웃
       signOut();
-      logoutKakaoAccessStorage();
+      removeLoginProcessed();
 
       alert('로그아웃 되었습니다.');
     }

--- a/components/modal/DeleteAccount.tsx
+++ b/components/modal/DeleteAccount.tsx
@@ -9,7 +9,7 @@ import DangerIcon from '@/public/images/icon-danger.svg';
 import { deleteUser } from '@/service/user.api';
 import useUser from '@/hooks/useUser';
 import { revokeGoogleAccess, revokeKakaoAccess } from '@/service/auth.api';
-import { getKakaoAccessToken } from '@/lib/kakaoStorage';
+import { removeLoginProcessed, removeProfileUpdated } from '@/lib/kakaoStorage';
 
 /**
  * 회원 탈퇴 모달 컴포넌트.
@@ -24,6 +24,8 @@ export default function DeleteAccount() {
   const { mutate: deleteUserMutate, isPending } = useMutation({
     mutationFn: deleteUser,
     onSuccess: () => {
+      removeProfileUpdated();
+      removeLoginProcessed();
       alert('회원탈퇴가 완료되었습니다.');
       clear();
     },
@@ -41,9 +43,8 @@ export default function DeleteAccount() {
     }
 
     // STUB 카카오 연동 해제
-    const kakaoAccessToken = getKakaoAccessToken();
-    if (kakaoAccessToken) {
-      await revokeKakaoAccess(kakaoAccessToken);
+    if (session.data?.kakaoAccessToken) {
+      await revokeKakaoAccess(session.data?.kakaoAccessToken);
     }
 
     // STUB 세션 로그아웃

--- a/components/modal/DeleteAccount.tsx
+++ b/components/modal/DeleteAccount.tsx
@@ -8,7 +8,8 @@ import Buttons from '@/components/Buttons';
 import DangerIcon from '@/public/images/icon-danger.svg';
 import { deleteUser } from '@/service/user.api';
 import useUser from '@/hooks/useUser';
-import { revokeGoogleAccess } from '@/service/auth.api';
+import { revokeGoogleAccess, revokeKakaoAccess } from '@/service/auth.api';
+import { getKakaoAccessToken } from '@/lib/kakaoStorage';
 
 /**
  * 회원 탈퇴 모달 컴포넌트.
@@ -19,7 +20,7 @@ export default function DeleteAccount() {
   const { closeModal } = useModalStore();
   const session = useSession();
 
-  // STUB 회원 탈퇴 api 호출
+  // STUB 회원 탈퇴 api mutate
   const { mutate: deleteUserMutate, isPending } = useMutation({
     mutationFn: deleteUser,
     onSuccess: () => {
@@ -30,16 +31,22 @@ export default function DeleteAccount() {
   });
 
   const handleDeleteAccount = async () => {
-    // 회원 탈퇴 api 호출
+    // STUB 회원 탈퇴 api 호출
     deleteUserMutate();
     closeModal();
 
-    // 구글 연동 해제
-    if (session.data?.accessToken) {
-      await revokeGoogleAccess(session.data.accessToken);
+    // STUB 구글 연동 해제
+    if (session.data?.googleAccessToken) {
+      await revokeGoogleAccess(session.data.googleAccessToken);
     }
 
-    // 세션 로그아웃
+    // STUB 카카오 연동 해제
+    const kakaoAccessToken = getKakaoAccessToken();
+    if (kakaoAccessToken) {
+      await revokeKakaoAccess(kakaoAccessToken);
+    }
+
+    // STUB 세션 로그아웃
     await signOut({ redirect: false });
   };
 

--- a/contexts/AuthProvider.tsx
+++ b/contexts/AuthProvider.tsx
@@ -1,0 +1,14 @@
+'use client';
+
+import { ReactNode } from 'react';
+import { SessionProvider } from 'next-auth/react';
+
+interface AuthProviderProps {
+  children: ReactNode;
+}
+
+const AuthProvider = ({ children }: AuthProviderProps) => {
+  return <SessionProvider>{children}</SessionProvider>;
+};
+
+export default AuthProvider;

--- a/hooks/useKakao.ts
+++ b/hooks/useKakao.ts
@@ -1,5 +1,7 @@
+// import { getProfileUpdated } from '@/lib/kakaoStorage';
+import { useCallback } from 'react';
+
 import {
-  getKakaoAccessToken,
   getLoginProcessed,
   getProfileUpdated,
   setLoginProcessed,
@@ -9,82 +11,59 @@ import { signIn, signUp } from '@/service/auth.api';
 import { updateUser } from '@/service/user.api';
 
 interface IKakaoLogin {
-  accessToken: string;
-  refreshToken: string;
-  user: { email: string; nickname: string; id: number; image: string };
+  id: number;
+  user: { email: string; nickname: string; image: string };
 }
 
-const kakaoLogin = async (
-  { accessToken, refreshToken, user: userData }: IKakaoLogin,
-  reload: () => void,
-) => {
-  // 만약 이미 처리된 경우, 중복 실행 방지
-  if (getLoginProcessed()) {
-    return;
-  }
+const useKakaoLogin = () => {
+  const kakaoLogin = useCallback(
+    async ({ id, user: userData }: IKakaoLogin, reload: () => void) => {
+      if (getLoginProcessed()) return;
 
-  // 로그인에 필요한 정보 추출
-  const { email, nickname, id, image } = userData;
+      // 로그인에 필요한 정보 추출
+      const { email, nickname, image } = userData;
 
-  // STUB 이메일 없을 경우, 임시 이메일 생성
-  const userEmail = email || `${id}@kakao.com`;
-  // STUB 비밀번호는 일반 사용자 ID와 동일하게 생성
-  // REVIEW 보안 이슈가 있을 수 있음
-  const userPassword = `kakao${id}!`;
+      // STUB 이메일 없을 경우, 임시 이메일 생성
+      const userEmail = email || `${id}@kakao.com`;
+      // STUB 비밀번호는 일반 사용자 ID와 동일하게 생성
+      // REVIEW 보안 이슈가 있을 수 있음
+      const userPassword = `kakao${id}!`;
 
-  if (getKakaoAccessToken()) {
-    // STUB 기존 사용자: 로그인 시도
-    try {
-      await signIn({
-        email: userEmail,
-        password: userPassword,
-      });
-      alert('[카카오] 간편 로그인 완료 (이미 토큰 존재)');
-      console.log('간편 로그인 완료 (이미 토큰 존재)');
-    } catch (error) {
-      console.error('로그인 실패:', error);
-    }
-  } else {
-    // STUB 신규 사용자: 회원가입 시도
-    await signUp({
-      email: userEmail,
-      nickname,
-      password: userPassword,
-      passwordConfirmation: userPassword,
-    });
-    // STUB 회원가입 성공 후 로그인 시도
-    try {
-      await signIn({
-        email: userEmail,
-        password: userPassword,
-      });
-      alert('[카카오] 간편 회원가입 및 로그인 완료');
-      console.log('간편 회원가입 및 로그인 완료');
-    } catch (signInError) {
-      console.error('간편 회원가입 및 로그인 실패:', signInError);
-    }
-  }
+      try {
+        await signUp({
+          email: userEmail,
+          nickname,
+          password: userPassword,
+          passwordConfirmation: userPassword,
+        });
+      } catch {
+        await signIn({
+          email: userEmail,
+          password: userPassword,
+        });
 
-  // STUB 프로필 업데이트 (한 번만 실행)
-  if (!getProfileUpdated()) {
-    try {
-      await updateUser({
-        image: image || '',
-      });
-      console.log('프로필 업데이트 완료');
+        console.log('[카카오] 로그인 완료');
+      }
 
-      // STUB 프로필 업데이트 완료 시 로컬 스토리지에 저장
-      setProfileUpdated();
-    } catch {
-      console.log('프로필 업데이트 실패');
-    }
-  }
+      setLoginProcessed();
 
-  // STUB 로그인 처리 완료
-  localStorage.setItem('kakaoAccessToken', accessToken);
-  localStorage.setItem('kakaoRefreshToken', refreshToken);
-  setLoginProcessed();
-  reload();
+      // STUB 프로필 업데이트 (한 번만 실행)
+
+      if (!getProfileUpdated()) {
+        await updateUser({
+          image: image || '',
+        });
+        console.log('프로필 업데이트 완료');
+        setProfileUpdated();
+      }
+
+      // STUB 로그인 처리 완료
+      reload();
+    },
+    [],
+  );
+
+  return kakaoLogin;
 };
 
-export default kakaoLogin;
+export default useKakaoLogin;

--- a/hooks/useKakao.ts
+++ b/hooks/useKakao.ts
@@ -1,0 +1,90 @@
+import {
+  getKakaoAccessToken,
+  getLoginProcessed,
+  getProfileUpdated,
+  setLoginProcessed,
+  setProfileUpdated,
+} from '@/lib/kakaoStorage';
+import { signIn, signUp } from '@/service/auth.api';
+import { updateUser } from '@/service/user.api';
+
+interface IKakaoLogin {
+  accessToken: string;
+  refreshToken: string;
+  user: { email: string; nickname: string; id: number; image: string };
+}
+
+const kakaoLogin = async (
+  { accessToken, refreshToken, user: userData }: IKakaoLogin,
+  reload: () => void,
+) => {
+  // 만약 이미 처리된 경우, 중복 실행 방지
+  if (getLoginProcessed()) {
+    return;
+  }
+
+  // 로그인에 필요한 정보 추출
+  const { email, nickname, id, image } = userData;
+
+  // STUB 이메일 없을 경우, 임시 이메일 생성
+  const userEmail = email || `${id}@kakao.com`;
+  // STUB 비밀번호는 일반 사용자 ID와 동일하게 생성
+  // REVIEW 보안 이슈가 있을 수 있음
+  const userPassword = `kakao${id}!`;
+
+  if (getKakaoAccessToken()) {
+    // STUB 기존 사용자: 로그인 시도
+    try {
+      await signIn({
+        email: userEmail,
+        password: userPassword,
+      });
+      alert('[카카오] 간편 로그인 완료 (이미 토큰 존재)');
+      console.log('간편 로그인 완료 (이미 토큰 존재)');
+    } catch (error) {
+      console.error('로그인 실패:', error);
+    }
+  } else {
+    // STUB 신규 사용자: 회원가입 시도
+    await signUp({
+      email: userEmail,
+      nickname,
+      password: userPassword,
+      passwordConfirmation: userPassword,
+    });
+    // STUB 회원가입 성공 후 로그인 시도
+    try {
+      await signIn({
+        email: userEmail,
+        password: userPassword,
+      });
+      alert('[카카오] 간편 회원가입 및 로그인 완료');
+      console.log('간편 회원가입 및 로그인 완료');
+    } catch (signInError) {
+      console.error('간편 회원가입 및 로그인 실패:', signInError);
+    }
+  }
+
+  // STUB 프로필 업데이트 (한 번만 실행)
+  if (!getProfileUpdated()) {
+    try {
+      await updateUser({
+        image: image || '',
+      });
+      console.log('프로필 업데이트 완료');
+
+      // STUB 프로필 업데이트 완료 시 로컬 스토리지에 저장
+      setProfileUpdated();
+    } catch {
+      console.log('프로필 업데이트 실패');
+    }
+  }
+
+  // STUB 로그인 처리 완료
+  localStorage.setItem('kakaoAccessToken', accessToken);
+  localStorage.setItem('kakaoRefreshToken', refreshToken);
+  setLoginProcessed();
+  reload();
+};
+
+export default kakaoLogin;

--- a/lib/kakaoStorage.ts
+++ b/lib/kakaoStorage.ts
@@ -1,0 +1,47 @@
+/**
+ * @description 카카오 로그인 시 발급받은 토큰을 저장하는 로컬 스토리지
+ */
+
+// 로컬 스토리지에서 값 가져오기 함수들
+const getLoginProcessed = () => localStorage.getItem('kakaoLoginProcessed');
+const getProfileUpdated = () => localStorage.getItem('profileUpdated');
+const getKakaoAccessToken = () => localStorage.getItem('kakaoAccessToken');
+const getKakaoRefreshToken = () => localStorage.getItem('kakaoRefreshToken');
+
+// 로컬 스토리지에 값 저장하기 함수들
+const setLoginProcessed = () =>
+  localStorage.setItem('kakaoLoginProcessed', 'true');
+const setProfileUpdated = () => localStorage.setItem('profileUpdated', 'true');
+
+// 로컬 스토리지에서 값 삭제하기 함수들
+const removeLoginProcessed = () =>
+  localStorage.removeItem('kakaoLoginProcessed');
+const removeProfileUpdated = () => localStorage.removeItem('profileUpdated');
+const removeKakaoAccessToken = () =>
+  localStorage.removeItem('kakaoAccessToken');
+const removeKakaoRefreshToken = () =>
+  localStorage.removeItem('kakaoRefreshToken');
+
+// 카카오 회원 탈퇴 시 로컬 스토리지에 저장된 토큰 정보를 삭제하는 함수
+const revokeKakaoAccessStorage = () => {
+  removeKakaoAccessToken();
+  removeKakaoRefreshToken();
+  removeLoginProcessed();
+  removeProfileUpdated();
+};
+
+// 카카오 로그아웃 시 로컬 스토리지에 저장된 토큰 정보를 삭제하는 함수
+const logoutKakaoAccessStorage = () => {
+  removeLoginProcessed();
+};
+
+export {
+  getLoginProcessed,
+  getProfileUpdated,
+  getKakaoAccessToken,
+  getKakaoRefreshToken,
+  setLoginProcessed,
+  setProfileUpdated,
+  revokeKakaoAccessStorage,
+  logoutKakaoAccessStorage,
+};

--- a/lib/kakaoStorage.ts
+++ b/lib/kakaoStorage.ts
@@ -3,45 +3,22 @@
  */
 
 // 로컬 스토리지에서 값 가져오기 함수들
-const getLoginProcessed = () => localStorage.getItem('kakaoLoginProcessed');
 const getProfileUpdated = () => localStorage.getItem('profileUpdated');
-const getKakaoAccessToken = () => localStorage.getItem('kakaoAccessToken');
-const getKakaoRefreshToken = () => localStorage.getItem('kakaoRefreshToken');
+const getLoginProcessed = () => localStorage.getItem('loginProcessed');
 
 // 로컬 스토리지에 값 저장하기 함수들
-const setLoginProcessed = () =>
-  localStorage.setItem('kakaoLoginProcessed', 'true');
 const setProfileUpdated = () => localStorage.setItem('profileUpdated', 'true');
+const setLoginProcessed = () => localStorage.setItem('loginProcessed', 'true');
 
 // 로컬 스토리지에서 값 삭제하기 함수들
-const removeLoginProcessed = () =>
-  localStorage.removeItem('kakaoLoginProcessed');
 const removeProfileUpdated = () => localStorage.removeItem('profileUpdated');
-const removeKakaoAccessToken = () =>
-  localStorage.removeItem('kakaoAccessToken');
-const removeKakaoRefreshToken = () =>
-  localStorage.removeItem('kakaoRefreshToken');
-
-// 카카오 회원 탈퇴 시 로컬 스토리지에 저장된 토큰 정보를 삭제하는 함수
-const revokeKakaoAccessStorage = () => {
-  removeKakaoAccessToken();
-  removeKakaoRefreshToken();
-  removeLoginProcessed();
-  removeProfileUpdated();
-};
-
-// 카카오 로그아웃 시 로컬 스토리지에 저장된 토큰 정보를 삭제하는 함수
-const logoutKakaoAccessStorage = () => {
-  removeLoginProcessed();
-};
+const removeLoginProcessed = () => localStorage.removeItem('loginProcessed');
 
 export {
-  getLoginProcessed,
   getProfileUpdated,
-  getKakaoAccessToken,
-  getKakaoRefreshToken,
-  setLoginProcessed,
   setProfileUpdated,
-  revokeKakaoAccessStorage,
-  logoutKakaoAccessStorage,
+  removeProfileUpdated,
+  getLoginProcessed,
+  setLoginProcessed,
+  removeLoginProcessed,
 };

--- a/next.config.ts
+++ b/next.config.ts
@@ -6,6 +6,7 @@ const nextConfig: NextConfig = {
       'example.com',
       'sprint-fe-project.s3.ap-northeast-2.amazonaws.com',
       'ifh.cc',
+      'lh3.googleusercontent.com',
     ], // 허용할 도메인 추가
   },
   webpack(config) {

--- a/next.config.ts
+++ b/next.config.ts
@@ -7,6 +7,7 @@ const nextConfig: NextConfig = {
       'sprint-fe-project.s3.ap-northeast-2.amazonaws.com',
       'ifh.cc',
       'lh3.googleusercontent.com',
+      'k.kakaocdn.net',
     ], // 허용할 도메인 추가
   },
   webpack(config) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "lucide-react": "^0.471.2",
         "mdx-loader": "^3.0.2",
         "next": "15.1.4",
+        "next-auth": "^4.24.11",
         "next-themes": "^0.4.4",
         "prettier-plugin-tailwindcss": "^0.6.9",
         "react": "^18.3.1",
@@ -1857,7 +1858,6 @@
       "version": "7.26.0",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.0.tgz",
       "integrity": "sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
@@ -3041,6 +3041,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@panva/hkdf": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.2.1.tgz",
+      "integrity": "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -8333,6 +8342,15 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/copy-descriptor": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
@@ -12260,6 +12278,15 @@
         "jiti": "bin/jiti.js"
       }
     },
+    "node_modules/jose": {
+      "version": "4.15.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
+      "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -13417,6 +13444,47 @@
         }
       }
     },
+    "node_modules/next-auth": {
+      "version": "4.24.11",
+      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-4.24.11.tgz",
+      "integrity": "sha512-pCFXzIDQX7xmHFs4KVH4luCjaCbuPRtZ9oBUjUhOk84mZ9WVPf94n87TxYI4rSRf9HmfHEF8Yep3JrYDVOo3Cw==",
+      "license": "ISC",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@panva/hkdf": "^1.0.2",
+        "cookie": "^0.7.0",
+        "jose": "^4.15.5",
+        "oauth": "^0.9.15",
+        "openid-client": "^5.4.0",
+        "preact": "^10.6.3",
+        "preact-render-to-string": "^5.1.19",
+        "uuid": "^8.3.2"
+      },
+      "peerDependencies": {
+        "@auth/core": "0.34.2",
+        "next": "^12.2.5 || ^13 || ^14 || ^15",
+        "nodemailer": "^6.6.5",
+        "react": "^17.0.2 || ^18 || ^19",
+        "react-dom": "^17.0.2 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@auth/core": {
+          "optional": true
+        },
+        "nodemailer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/next-auth/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/next-themes": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.4.tgz",
@@ -13571,6 +13639,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/oauth": {
+      "version": "0.9.15",
+      "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
+      "integrity": "sha512-a5ERWK1kh38ExDEfoO6qUHJb32rd7aYmPHuyCu3Fta/cnICvYmgd2uhuKXvPD+PXB+gCEYYEaQdIRAjCOwAKNA==",
+      "license": "MIT"
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -13807,6 +13881,15 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/oidc-token-hash": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.0.3.tgz",
+      "integrity": "sha512-IF4PcGgzAr6XXSff26Sk/+P4KZFJVuHAJZj3wgO3vX2bMdNVp/QXTP3P7CEm9V1IdG8lDLY3HhiqpsE/nOwpPw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^10.13.0 || >=12.0.0"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -13834,6 +13917,48 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/openid-client": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.7.1.tgz",
+      "integrity": "sha512-jDBPgSVfTnkIh71Hg9pRvtJc6wTwqjRkN88+gCFtYWrlP4Yx2Dsrow8uPi3qLr/aeymPF3o2+dS+wOpglK04ew==",
+      "license": "MIT",
+      "dependencies": {
+        "jose": "^4.15.9",
+        "lru-cache": "^6.0.0",
+        "object-hash": "^2.2.0",
+        "oidc-token-hash": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/openid-client/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/openid-client/node_modules/object-hash": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
+      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/openid-client/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -14579,6 +14704,34 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "license": "MIT"
     },
+    "node_modules/preact": {
+      "version": "10.25.4",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.25.4.tgz",
+      "integrity": "sha512-jLdZDb+Q+odkHJ+MpW/9U5cODzqnB+fy2EiHSZES7ldV5LK7yjlVzTp7R8Xy6W6y75kfK8iWYtFVH7lvjwrCMA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/preact-render-to-string": {
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-5.2.6.tgz",
+      "integrity": "sha512-JyhErpYOvBV1hEPwIxc/fHWXPfnEGdRKxc8gFdAZ7XV4tlzyzG847XAyEZqoDnynP88akM4eaHcSOzNcLWFguw==",
+      "license": "MIT",
+      "dependencies": {
+        "pretty-format": "^3.8.0"
+      },
+      "peerDependencies": {
+        "preact": ">=10"
+      }
+    },
+    "node_modules/preact-render-to-string/node_modules/pretty-format": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-3.8.0.tgz",
+      "integrity": "sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew==",
+      "license": "MIT"
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -15265,7 +15418,6 @@
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
       "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/regenerator-transform": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "lucide-react": "^0.471.2",
     "mdx-loader": "^3.0.2",
     "next": "15.1.4",
+    "next-auth": "^4.24.11",
     "next-themes": "^0.4.4",
     "prettier-plugin-tailwindcss": "^0.6.9",
     "react": "^18.3.1",

--- a/service/auth.api.ts
+++ b/service/auth.api.ts
@@ -5,7 +5,7 @@ import {
   AuthResponse,
   SignInProviderParams,
 } from '@/types/auth.type';
-import { revokeKakaoAccessStorage } from '@/lib/kakaoStorage';
+import { removeProfileUpdated } from '@/lib/kakaoStorage';
 
 import instance from './axios';
 
@@ -132,7 +132,7 @@ const revokeKakaoAccess = async (accessToken: string) => {
     });
     console.log('kakao 계정 연동 해제 완료');
 
-    revokeKakaoAccessStorage();
+    removeProfileUpdated();
   } catch (error) {
     console.error('kakao 회원 탈퇴 에러:', error);
     throw error;

--- a/service/auth.api.ts
+++ b/service/auth.api.ts
@@ -1,8 +1,11 @@
+import axios from 'axios';
+
 import {
   SignUpParams,
   AuthResponse,
   SignInProviderParams,
 } from '@/types/auth.type';
+import { revokeKakaoAccessStorage } from '@/lib/kakaoStorage';
 
 import instance from './axios';
 
@@ -115,10 +118,32 @@ const revokeGoogleAccess = async (accessToken: string) => {
   }
 };
 
+/**
+ * Kakao Access Token 폐기(탈퇴 시)
+ * @param accessToken Kakao Access Token
+ */
+const revokeKakaoAccess = async (accessToken: string) => {
+  try {
+    await axios.post('https://kapi.kakao.com/v1/user/unlink', null, {
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
+    console.log('kakao 계정 연동 해제 완료');
+
+    revokeKakaoAccessStorage();
+  } catch (error) {
+    console.error('kakao 회원 탈퇴 에러:', error);
+    throw error;
+  }
+};
+
 export {
   signUp,
   signIn,
   refreshAccessToken,
   signInProvider,
   revokeGoogleAccess,
+  revokeKakaoAccess,
 };

--- a/types/auth.type.ts
+++ b/types/auth.type.ts
@@ -1,4 +1,3 @@
-import { OauthProvider } from './oauth.type';
 import { IUser } from './user.type';
 
 interface SignUpParams {
@@ -14,7 +13,7 @@ interface SignInParams {
 }
 
 interface SignInProviderParams {
-  provider: OauthProvider;
+  provider: string;
   state?: string;
   redirectUri?: string;
   token: string;

--- a/types/next-auth.type.ts
+++ b/types/next-auth.type.ts
@@ -5,11 +5,7 @@ declare module 'next-auth' {
     googleAccessToken?: string;
     googleIdToken?: string;
     kakaoAccessToken?: string;
-    kakao: {
-      accessToken: string;
-      refreshToken: string;
-      id: number;
-    };
+    id?: number;
   }
 
   export interface JWT {

--- a/types/next-auth.type.ts
+++ b/types/next-auth.type.ts
@@ -1,13 +1,20 @@
 import { DefaultSession } from 'next-auth';
 
 declare module 'next-auth' {
-  interface Session extends DefaultSession {
-    accessToken?: string;
-    idToken?: string;
+  export interface Session extends DefaultSession {
+    googleAccessToken?: string;
+    googleIdToken?: string;
+    kakaoAccessToken?: string;
+    kakao: {
+      accessToken: string;
+      refreshToken: string;
+      id: number;
+    };
   }
 
-  interface JWT {
-    accessToken?: string;
-    idToken?: string;
+  export interface JWT {
+    googleAccessToken?: string;
+    googleIdToken?: string;
+    kakaoAccessToken?: string;
   }
 }

--- a/types/next-auth.type.ts
+++ b/types/next-auth.type.ts
@@ -1,0 +1,13 @@
+import { DefaultSession } from 'next-auth';
+
+declare module 'next-auth' {
+  interface Session extends DefaultSession {
+    accessToken?: string;
+    idToken?: string;
+  }
+
+  interface JWT {
+    accessToken?: string;
+    idToken?: string;
+  }
+}

--- a/types/oauth.type.ts
+++ b/types/oauth.type.ts
@@ -1,12 +1,7 @@
-enum OauthProvider {
-  GOOGLE,
-  KAKAO,
-}
-
 interface CreateOauthAppsParams {
   appSecret?: string;
   appKey: string;
-  provider: OauthProvider;
+  provider: string;
 }
 
 interface CreateOauthAppsResponse {
@@ -14,10 +9,9 @@ interface CreateOauthAppsResponse {
   updatedAt: string;
   appSecret: string | null;
   appkey: string;
-  provider: OauthProvider;
+  provider: string;
   teamId: string;
   id: number;
 }
 
-export { OauthProvider };
 export type { CreateOauthAppsParams, CreateOauthAppsResponse };

--- a/utils/randomNumber.ts
+++ b/utils/randomNumber.ts
@@ -1,0 +1,14 @@
+/**
+ * 중복되지않는 5자리 랜덤 숫자를 생성합니다.
+ * @returns
+ * 5자리 랜덤 숫자
+ */
+const randomNumber5 = () => {
+  let digits = '';
+  for (let i = 0; i < 5; i++) {
+    digits += Math.floor(Math.random() * 10);
+  }
+  return digits;
+};
+
+export default randomNumber5;


### PR DESCRIPTION
## 관련 이슈

<!-- 연관된 이슈 번호를 작성해주세요 예 #15 -->

close #170 

## 요약

<!-- 작업 내용에 대해 간단히 설명해주세요 -->
- 소셜 로그인 기능 구현(OauthForm 컴포넌트에 추가)
- next auth 패키징 추가
- 소셜 로그인 로딩 UI 컴포넌트 추가
- 회원탈퇴, 로그아웃에 소셜 로그인 포함
- next.config에 소셜 프로필을 가져오기위해 도메인 추가
- 소셜 로그인 인증상태 공유를 위한 provider 생성

## 변경 사항 설명

<!-- 구현한 내용에 대해 자세한 내용을 작성해 주세요 -->
- 소셜 로그인을 [next-auth](https://github.com/nextauthjs)를 이용해 구현 했습니다.
- 구글로그인은 정상적으로 제공된 엔드포인트로 완료하였습니다
- 카카오 로그인은 제공된 엔드포인트에서 인가코드만 받고 카카오에서 변환해준 액세스토큰을 리턴해주지않아 로그아웃 및 회원탈퇴가 진행되지않아 next-auth에서 리턴해주는 사용자값을 이용하여, signIn, signUp API 요청을 통해서 구현 되었습니다.
- 소셜 로그인 진행 시 로딩화면이 보이게 컴포넌트를 만들어 작성 해 주었습니다.
- .env 업데이트 되었습니다 [디스코드 스레드](https://discord.com/channels/1328227682705604628/1335642813077000267/1335983696574152764)에서 확인 부탁드립니다.(꼭 추가해줘야함)
- 소셜 회원탈퇴 요청 api 추가 작성 되었습니다.
- 카카오 로그인의 경우 사용자 이메일을 제공해주지않기때문에 리턴해주는 유저 ID를 이용하여, 별도 지정해준 이메일로 회원가입 및 로그인을 진행하게됩니다. 고유한 유저ID임으로 이메일 충돌이 발생하는 일은 없습니다.
- 다만, 닉네임의 경우 이름으로 지정이 되어있을때 동일한 닉네임으로 가입이 되어있을 경우 회원가입이 진행되지않아 닉네임뒤에 랜덤5가지 수를 붙혀서 가입하게 됩니다. 
- 카카오톡 패스워드의 경우 kakao${id} 로 지정 됩니다. 
- 소셜 로그인 후 리턴되는 액세스토큰과 리프레시토큰은 next auth의 세션에서 관리됩니다.
<!-- 추가적으로 리뷰를 원하는 부분을 알려주세요 -->

## 주의 사항
- 아직 패스워드 변경 관련해서는 테스트가 진행 되지않았습니다 추가로 확인해보겠습니다.
- 원래는 제공된 엔드포인트를 사용하여, 구현을 해야하지만 구글 로그인의 경우 인증된 토큰을 변환하여 리턴할때 프로젝트 엔드포인트에서 요구하는 Google Id 토큰(JWT) 값을 리턴해주어서 구현이 가능했지만, 카카오의 경우는 엔드포인트에서 요구하는 인가 코드를 리턴하지않고 해당 인가코드를 변환하여 사용할수있는 액세스토큰을 리턴합니다.
- 위와 같은 이유때문에 next auth를 이용해 카카오 소셜 로그인 구현이 불가능했고, next auth를 사용하지않고 인가 코드를 전달하여 프로젝트 엔드포인트를 이용하여 로그인을 진행 할 경우 서버에서 리턴되는 액세스토큰과 리프레시토큰이 카카오측에서 변환해준 사용가능한 토큰이 아닌 '자체 토큰' 을 리턴하게 됩니다. 고로, 서버 엔드포인트를 통해 카카오 로그인을 구현 할 경우 회원탈퇴 및 로그아웃이 진행 되지않아 해당 기능 구현을 위해 프로젝트 엔드포인트를 사용하여 로그인요청을 하지않고, next auth에서 리턴되는 사용자 정보값으로 회원가입 및 로그인으로 진행하였습니다.
- 카카오 로그인으로 진행할경우 패스워드는 고정이 되어버리기때문에 최초 로그인 시 보안에 취약할듯싶습니다.
- 구글 로그인은 next auth를 이용하여 로그인을 하고, 카카오 로그인은 별도 리다이렉트를 생성해 제공된 엔드포인트로 로그인 구현도 가능하지만 회원탈퇴는 불가능 하게 됩니다. 또한, 유저의 닉네임이 고유 ID로 전달되어, 숫자로 표기된다는 점 때문에 위와 같은 방식을 사용하였습니다
- 서버에서 제공해주지않는 기능을 프론트단에서 구현을 한다는것 자체가 개발 플로우에 위반이 되는 사항임을 인지하고 있으나, 그대로 두기에는 퀄리티가 떨어진다 생각하여 구현하게 되었습니다 🫠
- 해당 방식이 프로젝트에 큰 영향을 미친다면 제공된 엔드포인트로 소셜 로그인 진행 방식으로 하겠습니다(카카오만)
