### PR TITLE
자유게시판 리스트 페이지 게시글 삭제 기능

### DIFF
--- a/app/boards/ArticleList.tsx
+++ b/app/boards/ArticleList.tsx
@@ -38,6 +38,7 @@ function ArticleList({ keyword }: { keyword: string | undefined }) {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['articleList'] });
+      alert('게시글이 삭제되었습니다.');
     },
   });
 

--- a/app/boards/ArticleList.tsx
+++ b/app/boards/ArticleList.tsx
@@ -1,10 +1,12 @@
 'use client';
 
 import { useState } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import ArticleCard from '@/components/ArticleCard/ArticleCard';
 import SelectBox from '@/components/SelectBox';
 import useGetArticle from '@/hooks/useGetArticle';
+import { deleteArticle } from '@/service/article.api';
 
 import ArticleSkeleton from './ArticleSkeleton';
 import EmptyList from './EmptyList';
@@ -15,16 +17,28 @@ import EmptyList from './EmptyList';
  */
 function ArticleList({ keyword }: { keyword: string | undefined }) {
   const [option, setOption] = useState<'recent' | 'like'>('recent');
+  const queryClient = useQueryClient();
 
   const {
     data: articleList,
     isLoading,
     isError,
   } = useGetArticle({
-    queryKey: 'bestArticleList',
+    queryKey: 'articleList',
     pageSize: 100,
     orderBy: option,
     keyword: keyword ?? '',
+  });
+
+  const deleteArticleMutation = useMutation({
+    mutationFn: async (id: number) => {
+      if (confirm('게시글을 삭제하시겠습니까?')) {
+        await deleteArticle({ articleId: id });
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['articleList'] });
+    },
   });
 
   if (isError) return '에러가 발생했습니다.';
@@ -49,11 +63,15 @@ function ArticleList({ keyword }: { keyword: string | undefined }) {
           </div>
           <div className="mt-pr-32 flex flex-wrap justify-between gap-y-pr-24">
             {!isLoading ? (
-              <>
-                {articleList?.list.map((article) => {
-                  return <ArticleCard key={article.id} articleData={article} />;
-                })}
-              </>
+              articleList?.list.map((article) => (
+                <ArticleCard
+                  key={article.id}
+                  articleData={article}
+                  handleArticleDelete={() =>
+                    deleteArticleMutation.mutate(article.id)
+                  }
+                />
+              ))
             ) : (
               <ArticleSkeleton count={4} />
             )}

--- a/components/ArticleCard/ArticleCard.tsx
+++ b/components/ArticleCard/ArticleCard.tsx
@@ -22,9 +22,11 @@ const BEST_STYLE =
 function ArticleCard({
   type = 'normal',
   articleData,
+  handleArticleDelete,
 }: {
   type?: 'normal' | 'best';
   articleData: IArticle;
+  handleArticleDelete?: (id: number) => void;
 }) {
   const { id, title, image, createdAt, writer, likeCount } = articleData;
   const isBestCard = type === 'best';
@@ -46,10 +48,13 @@ function ArticleCard({
 
       <ArticleCardContent
         isBestCard={isBestCard}
+        id={id}
         title={title}
         image={image}
         writer={writer}
+        handleArticleDelete={handleArticleDelete}
       />
+
       {isBestCard && (
         <div className="mt-pr-12 mo:mt-0">
           <p className="text-14m text-t-disabled mo:text-12m">

--- a/components/ArticleCard/ArticleCardContent.tsx
+++ b/components/ArticleCard/ArticleCardContent.tsx
@@ -12,17 +12,21 @@ import useUserStore from '@/stores/useUser.store';
  * @returns {JSX.Element} 게시글 카드의 제목, 이미지가 포함된 Card Content 컴포넌트
  */
 function ArticleCardContent({
+  id,
   isBestCard,
   title,
   image,
   writer,
+  handleArticleDelete,
 }: {
+  id: number;
   title: string;
   image: string | null;
   isBestCard: boolean;
   writer: {
     id: number;
   };
+  handleArticleDelete?: (id: number) => void;
 }) {
   const { user: userData } = useUserStore();
 
@@ -49,7 +53,7 @@ function ArticleCardContent({
             />
           </div>
         )}
-        {!isBestCard && userData?.id === writer.id && (
+        {!isBestCard && userData?.id === writer.id && handleArticleDelete && (
           <div
             className="ml-pr-16 mo:hidden"
             onClick={(e: React.MouseEvent) => {
@@ -58,7 +62,7 @@ function ArticleCardContent({
           >
             <KebabDropDown
               onEdit={() => alert('수정')}
-              onDelete={() => alert('삭제')}
+              onDelete={() => handleArticleDelete(id)}
             />
           </div>
         )}

--- a/hooks/useGetArticle.ts
+++ b/hooks/useGetArticle.ts
@@ -18,7 +18,7 @@ const useGetArticle = ({
   deviceType,
 }: GetArticleProps) => {
   const { data, isLoading, isError } = useQuery({
-    queryKey: [{ queryKey }, orderBy, deviceType, keyword],
+    queryKey: [queryKey, orderBy, deviceType, keyword],
     queryFn: () =>
       getArticleList({
         pageSize: pageSize,


### PR DESCRIPTION
## 관련 이슈

close #176 

## 요약

자유게시판 게시글 삭제 기능 추가했습니다.

## 변경 사항 설명

자유게시판 게시글 삭제 기능 추가했습니다.
현재 글쓰기 페이지 작업이 아직 병합되지 않아 테스트를 하시려면 직접 게시글 생성 API 요청하여 글 생성하셔서 삭제 테스트를 해보셔야 합니다.

그리고 `article.api.ts`의 API의 경로도(`/article -> /articles`) 수정하셔야 정상 동작합니다.
해당 PR에서 경로를 수정하지 않은 이유는 다른 PR에서 이미 수정을 하고 병합 예정이라 하지 않았습니다. 

되도록 아래 첨부드린 영상 참고하셔서 확인만 부탁드립니다.

https://github.com/user-attachments/assets/d093ac08-34cf-4038-b15f-34e9b83d3cce


