### PR TITLE
#192 1차 QA 반영 및 input 디바운스 적용

### DIFF
--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -50,13 +50,13 @@ function SignupPage() {
     <form onSubmit={handleSubmit}>
       <div className="auth_input-list">
         <InputField
-          label="이름"
+          label="닉네임"
           type="text"
           name="nickname"
           value={formData.nickname}
           onChange={handleInputChange}
           errorMessage={errorMessage.nickname}
-          placeholder="이름을 입력해주세요."
+          placeholder="닉네임을 입력해주세요."
           required
         />
 

--- a/app/mypage/page.tsx
+++ b/app/mypage/page.tsx
@@ -112,7 +112,7 @@ export default function MyPage() {
 
         {/* 닉네임 */}
         <InputField
-          label="이름"
+          label="닉네임"
           name="nickname"
           value={formData.nickname}
           placeholder={user.nickname}

--- a/contexts/DeviceTypeContext.tsx
+++ b/contexts/DeviceTypeContext.tsx
@@ -1,4 +1,3 @@
-import useDebounce from '@/hooks/useDebounce';
 import {
   createContext,
   useCallback,
@@ -7,6 +6,8 @@ import {
   useMemo,
   useState,
 } from 'react';
+
+import useDebounce from '@/hooks/useDebounce';
 
 export type DeviceType = 'desktop' | 'tablet' | 'mobile';
 
@@ -26,14 +27,15 @@ export function DeviceTypeProvider({
 }) {
   const [deviceType, setDeviceType] = useState<DeviceType>(getDeviceType());
 
-  const handleResize = useCallback(
-    useDebounce(() => {
-      if (typeof window !== 'undefined') {
-        setDeviceType(getDeviceType());
-      }
-    }, 100),
-    [],
-  );
+  const debouncedResize = useDebounce(() => {
+    if (typeof window !== 'undefined') {
+      setDeviceType(getDeviceType());
+    }
+  }, 100);
+
+  const handleResize = useCallback(() => {
+    debouncedResize();
+  }, [debouncedResize]);
 
   useEffect(() => {
     if (typeof window === 'undefined') return;

--- a/hooks/useDebounce.ts
+++ b/hooks/useDebounce.ts
@@ -1,20 +1,25 @@
-import { useCallback, useRef } from 'react';
+import { useCallback, useRef, useEffect } from 'react';
 
 function useDebounce(callback: (...args: any[]) => void, delay: number) {
   const callbackRef = useRef(callback);
-  const timeoutRef = useRef<NodeJS.Timeout>(null);
+  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  // callback이 변경될 때마다 최신 콜백을 갱신
+  useEffect(() => {
+    callbackRef.current = callback;
+  }, [callback]);
 
   return useCallback(
     (...args: any[]) => {
       if (timeoutRef.current) {
         clearTimeout(timeoutRef.current);
       }
-      timeoutRef.current = setTimeout(
-        () => callbackRef.current(...args),
-        delay,
-      );
+      timeoutRef.current = setTimeout(() => {
+        callbackRef.current(...args);
+      }, delay);
     },
-    [delay, callback],
+    [delay],
   );
 }
+
 export default useDebounce;


### PR DESCRIPTION
## 관련 이슈

<!-- 연관된 이슈 번호를 작성해주세요 예 #15 -->

close #192 

## 요약

<!-- 작업 내용에 대해 간단히 설명해주세요 -->
- Input 에러 노출 조건 디바운스 적용(useForm 수정)
- 이름 => 닉네임 통일
- 디바운스 훅, 디바이스 타입 훅 개선

## 변경 사항 설명

<!-- 구현한 내용에 대해 자세한 내용을 작성해 주세요 -->
- `useForm` 훅에 `js doc` 추가 했습니다.
- input text 체인지 반영사항과 에러 노출 디바운스 함수 분리하여, 적용했습니다.
- input에 디바운스 적용을 위해서 기존의 `useDebounce`훅을 수정했습니다.
 - 이전 코드 : `useEffect` 없이 `callbackRef.current`에 `callback`을 한 번만 할당
 - 수정 코드 : `useEffect`로 `callback`이 변경될 때마다 `callbackRef.current = callback`을 갱신
 - 개선 이유 : 디바운스된 콜백이 실행되는 시점에 항상 가장 최신의 콜백을 사용해야하는데 이전 코드에서는 콜백이 바뀌어도 `callbackRef.current`가 초기에만 설정된 값 그대로기때문에 옛날 콜백을 사용 할 수 있다는 위험이 있어서 개선함
- 해당 훅을 개선하던 중 기존의 디바이스훅에서 lint에러가 발생해 수정되었습니다
 - 결과와 동작에는 큰 차이가 없습니다. 다만, 디바운스 함수와 실제 이벤트 핸들러를 분리한 것 뿐입니다.
 - 전체 동작확인은 #191 해당 PR 반영 시 확인 가능합니다

## 동작

https://github.com/user-attachments/assets/c70570e4-b627-409a-8379-a842015c7223



<!-- 추가적으로 리뷰를 원하는 부분을 알려주세요 -->


