### PR TITLE
#194 404페이지 조건분기 타입 수정

### DIFF
--- a/app/[teamId]/(index)/page.tsx
+++ b/app/[teamId]/(index)/page.tsx
@@ -85,7 +85,9 @@ export default function TeamPage() {
   };
 
   // teamId가 숫자가 아니라면 또는 4자리 숫자가 아니라면
-  if (typeof teamId !== 'number' || teamId < 1000 || teamId > 9999) {
+  const parsedTeamId = Number(teamId);
+
+  if (isNaN(parsedTeamId) || parsedTeamId < 1000 || parsedTeamId > 9999) {
     return <NotFound />;
   }
 


### PR DESCRIPTION
## 관련 이슈

<!-- 연관된 이슈 번호를 작성해주세요 예 #15 -->

close #194 

## 요약

<!-- 작업 내용에 대해 간단히 설명해주세요 -->
- /[teamId]/(index)/page.tsx 내부 404페이지 조건분기 수정

## 변경 사항 설명

<!-- 구현한 내용에 대해 자세한 내용을 작성해 주세요 -->
- 기존 조건은 `teamId`가 숫자타입이 아닐때를 처리 하고있었는데 확인해보니, `teamId`는 `number`가 아닌 `string`으로 넘어오더라구요
- 그래서 그 string을 `Number`로 변환 후 범위안에 포함되어있지않으면 404 페이지를 보여주게 했습니다.
- 어떠한 그룹에도 가입되어있지않을때 팀생성을 통해 해당 페이지로 넘어갈때 정상적으로 팀 페이지 화면이 노출됩니다.
- `http://localhost:3000/sdf` 와 같은 존재하지않는 경로로 이동할 경우 404페이지가 노출 됩니다.
<!-- 추가적으로 리뷰를 원하는 부분을 알려주세요 -->

## 주의 사항
