### PR TITLE
#200 팀페이지 조건 분기

### DIFF
--- a/app/[teamId]/(index)/page.tsx
+++ b/app/[teamId]/(index)/page.tsx
@@ -28,7 +28,7 @@ import GroupReport from './GroupReport';
 export default function TeamPage() {
   const { memberships } = useUser(true);
   const { teamId } = useParams();
-  const { group, members, refetch } = useGroup(Number(teamId));
+  const { group, members, refetch, isPending } = useGroup(Number(teamId));
   const { taskLists, refetchById, removeById } = useTaskLists();
 
   const currentMembership = memberships?.find(
@@ -84,12 +84,11 @@ export default function TeamPage() {
     return deleteTaskList({ groupId: group.id, ...params });
   };
 
-  // teamId가 숫자가 아니라면 또는 4자리 숫자가 아니라면
-  if (typeof teamId !== 'number' || teamId < 1000 || teamId > 9999) {
-    return <NotFound />;
-  }
+  //TODO 그룹 데이터 로딩 중. 로딩 컴포넌트 보여주기
+  if (!group && isPending) return null;
 
-  if (!group) return null;
+  //팀이 없을 경우
+  if (!group) return <NotFound />;
 
   return (
     <Container>

--- a/components/layout/Header/Headers.tsx
+++ b/components/layout/Header/Headers.tsx
@@ -61,14 +61,14 @@ function Headers() {
     }
     const group = groups.find((group) => group.id === groupId);
     if (group) setCurrentGroup(group);
-    else router.push('/');
+    else setCurrentGroup(null);
   }, [groupId, groups, isPending, router]);
 
   return (
     <header className="fixed z-40 flex w-full items-center border-b bg-b-secondary transition-all">
       <nav className="mx-auto flex h-pr-60 w-pr-1280 items-center justify-between px-pr-40 mo:px-pr-16 ta:px-pr-25">
         <div className="flex items-center gap-pr-40 ta:gap-pr-24">
-          {deviceType === 'mobile' && groups && (
+          {deviceType === 'mobile' && (
             <>
               <SideNavigationTrigger
                 src="/images/icon-gnb-menu.svg"


### PR DESCRIPTION
## 관련 이슈

close #200 

## 변경 사항 설명

조건 분기

-  팀 데이터 로딩 중 : 빈 페이지. 로딩 스피너로 변경 예정
-  팀 데이터 불러오기 실패 : 404페이지
-  팀 데이터 불어오기 : 페이지 보여주기

## 버그

### 데이터 불러오기 실패 시 리다이렉트 발생

**문제**
팀 데이터 불러오기 실패 시 랜딩 페이지로 리다이렉트 되는데, 원인이 무엇인지는 잘 모르겠습니다.

**해결**
과거 글로벌 네비게이션에 선택된 팀이 없을 때 리다이렉트 시키는 코드를 넣어뒀었는데, 이를 제거했습니다!
