### PR TITLE
#203 URL 문자열 생성 함수 구현 및 할 일 목록 이동 경로 수정

### DIFF
--- a/app/[teamId]/(index)/GroupTaskList.tsx
+++ b/app/[teamId]/(index)/GroupTaskList.tsx
@@ -43,7 +43,7 @@ export default function GroupTaskList({
   const handleClickTaskList = () => {
     const url = createUrlString({
       pathname: [taskList.groupId, 'tasklist'],
-      searchParams: { id: taskList.id },
+      queryParams: { id: taskList.id },
     });
     router.push(url);
   };

--- a/app/[teamId]/(index)/GroupTaskList.tsx
+++ b/app/[teamId]/(index)/GroupTaskList.tsx
@@ -7,6 +7,7 @@ import { RoleType } from '@/types/group.type';
 import { _DeleteTaskListParams, _UpdateTaskListParams } from './TeamPage.type';
 import { PointColorType } from './GroupTaskListWrapper';
 import TaskProgressBadge from './TaskProgressBadge';
+import createUrlString from '@/utils/createUrlString';
 
 type IPointColorClasses = {
   [key in PointColorType]: string;
@@ -40,7 +41,11 @@ export default function GroupTaskList({
   const router = useRouter();
 
   const handleClickTaskList = () => {
-    router.push(`/${taskList.groupId}/${taskList.id}`);
+    const url = createUrlString({
+      pathname: [taskList.groupId, 'tasklist'],
+      searchParams: { id: taskList.id },
+    });
+    router.push(url);
   };
 
   const handleClickEdit = () => {

--- a/app/[teamId]/(index)/GroupTaskList.tsx
+++ b/app/[teamId]/(index)/GroupTaskList.tsx
@@ -3,11 +3,11 @@ import { useRouter } from 'next/navigation';
 import KebabDropDown from '@/components/KebabDropDown';
 import { ITaskList } from '@/types/taskList.type';
 import { RoleType } from '@/types/group.type';
+import createUrlString from '@/utils/createUrlString';
 
 import { _DeleteTaskListParams, _UpdateTaskListParams } from './TeamPage.type';
 import { PointColorType } from './GroupTaskListWrapper';
 import TaskProgressBadge from './TaskProgressBadge';
-import createUrlString from '@/utils/createUrlString';
 
 type IPointColorClasses = {
   [key in PointColorType]: string;

--- a/utils/createUrlString.ts
+++ b/utils/createUrlString.ts
@@ -1,7 +1,7 @@
 interface CreateUrlStringParams {
   origin?: string;
   pathname?: (string | number)[];
-  searchParams?: Record<string, string | number>;
+  queryParams?: Record<string, string | number>;
 }
 
 /**
@@ -9,7 +9,7 @@ interface CreateUrlStringParams {
  * @param {CreateUrlStringParams} params - URL 생성에 필요한 매개변수
  * @param {string} [params.origin] - 베이스 URL (기본값: 현재 페이지의 origin)
  * @param {(string|number)[]} [params.pathname] - URL 경로 배열
- * @param {Record<string, string|number>} [params.searchParams] - URL 쿼리 파라미터 객체
+ * @param {Record<string, string|number>} [params.queryParams] - URL 쿼리 파라미터 객체
  *
  * @returns {string} 생성된 URL 문자열
  *
@@ -33,7 +33,7 @@ interface CreateUrlStringParams {
 const createUrlString = ({
   origin,
   pathname,
-  searchParams,
+  queryParams,
 }: CreateUrlStringParams = {}) => {
   const url = new URL(origin || location.origin);
 
@@ -41,8 +41,8 @@ const createUrlString = ({
     url.pathname = '/' + pathname.map(String).join('/');
   }
 
-  if (searchParams) {
-    for (const [key, value] of Object.entries(searchParams)) {
+  if (queryParams) {
+    for (const [key, value] of Object.entries(queryParams)) {
       url.searchParams.append(key, String(value));
     }
   }

--- a/utils/createUrlString.ts
+++ b/utils/createUrlString.ts
@@ -1,0 +1,52 @@
+interface CreateUrlStringParams {
+  origin?: string;
+  pathname?: (string | number)[];
+  searchParams?: Record<string, string | number>;
+}
+
+/**
+ * ### URL 문자열을 생성하는 함수
+ * @param {CreateUrlStringParams} params - URL 생성에 필요한 매개변수
+ * @param {string} [params.origin] - 베이스 URL (기본값: 현재 페이지의 origin)
+ * @param {(string|number)[]} [params.pathname] - URL 경로 배열
+ * @param {Record<string, string|number>} [params.searchParams] - URL 쿼리 파라미터 객체
+ *
+ * @returns {string} 생성된 URL 문자열
+ *
+ * @example
+ * ```ts
+ * // 상대 경로 사용법
+ * // /users/123/profile?sort=name&order=asc
+ * const url = createUrlString({
+ *   pathname: ['users', 123, 'profile'],
+ *   searchParams: { sort: 'name', order: 'asc' }
+ * });
+ *
+ * // 절대 경로 사용법
+ * // https://example.com/api/v1/data?limit=10&offset=20
+ * const customUrl = createUrlString({
+ *   origin: 'https://example.com',
+ *   pathname: ['api', 'v1', 'data'],
+ *   searchParams: { limit: 10, offset: 20 }
+ * });
+ */
+const createUrlString = ({
+  origin,
+  pathname,
+  searchParams,
+}: CreateUrlStringParams = {}) => {
+  const url = new URL(origin || location.origin);
+
+  if (pathname) {
+    url.pathname = '/' + pathname.map(String).join('/');
+  }
+
+  if (searchParams) {
+    for (const [key, value] of Object.entries(searchParams)) {
+      url.searchParams.append(key, String(value));
+    }
+  }
+  return origin ? url.toString() : url.pathname + url.search;
+};
+
+export default createUrlString;


### PR DESCRIPTION
## 관련 이슈

close #203 

## 변경 사항 설명

### URL 문자열 생성을 위한 유틸리티 함수 구현

경로와 URL 파라미터가 점점 길어지다 보니 가독성이 떨어지고,

URL 객체의 메스드를 활용하기에도 코드가 복잡했습니다.

그래서 까짓것 유틸 함수 한 개 만들었습니다.

**사용법**

 ```ts
 // 상대 경로 사용법
 // /users/123/profile?sort=name&order=asc
 const url = createUrlString({
   pathname: ['users', 123, 'profile'],
   searchParams: { sort: 'name', order: 'asc' }
 });
 
// 절대 경로 사용법
 // https://example.com/api/v1/data?limit=10&offset=20
 const customUrl = createUrlString({
   origin: 'https://example.com',
   pathname: ['api', 'v1', 'data'],
   searchParams: { limit: 10, offset: 20 }
 });
```
`origin` 프로퍼티를 전달하면 절대 경로로 반환되고, `origin`을 전달하지 않으면 상대 경로로 반환합니다.

저희 서비스 내부에서 이동할 경우에는 `origin`을 전달하지 않아도 됩니다.

### 할 일 목록 이동 경로 수정

원래는 `/[groupId]/[taskListId]`로 이동했었는데, 제가 잘 못 설정했습니다.

변경 사항에서는  `/[groupId]/tasklist`를 경로로 설정했습니다.

![image](https://github.com/user-attachments/assets/77eff466-d5d3-4553-a7a9-5b94323d935a)

추가적으로 해당 페이지에서 할 일 목록을 탭으로 이동하던데,

페이지 렌더링 및 URL 공유 시 유용하게 쓰일 거 같아서 `taskList`의 `id`를 `searchParams`의 `id`로 전달합니다.

그래서 `groupId`가 `1750`, `taskListId`가 `11354`일 때 이동 경로는 `/1750/tasklist?id=11354`가 됩니다.
