### PR TITLE
#209 console => 스낵바로 변경 및 세션 중복호출 방지

### DIFF
--- a/app/(auth)/addteam/page.tsx
+++ b/app/(auth)/addteam/page.tsx
@@ -11,6 +11,7 @@ import Profile from '@/components/Profile/Profile';
 import useUser from '@/hooks/useUser';
 import updatePayloadSubmit from '@/utils/updatePayload';
 import Buttons from '@/components/Buttons';
+import { useSnackbar } from '@/contexts/SnackBar.context';
 
 // STUB 초기값
 const INITIAL_VALUES = {
@@ -22,6 +23,8 @@ export default function AddTeamPage() {
   const { user, isPending, reload, groups } = useUser(true);
 
   const route = useRouter();
+
+  const { showSnackbar } = useSnackbar();
 
   // STUB 팀 생성 폼 상태
   const {
@@ -59,14 +62,13 @@ export default function AddTeamPage() {
     useMutation({
       mutationFn: createGroup,
       onSuccess: (response) => {
-        alert('팀 생성이 완료되었습니다');
-        console.log('팀 생성이 완료되었습니다', response);
+        showSnackbar('팀 생성이 완료되었습니다.');
         route.push(`/${response.id}`);
         resetForm();
         reload();
       },
       onError: () => {
-        alert('팀 생성에 실패했습니다');
+        showSnackbar('팀 생성에 실패했습니다. 다시 시도해주세요', 'error');
       },
     });
 

--- a/app/(auth)/jointeam/page.tsx
+++ b/app/(auth)/jointeam/page.tsx
@@ -7,10 +7,12 @@ import InputField from '@/components/InputField/InputField';
 import useForm from '@/hooks/useForm';
 import useUser from '@/hooks/useUser';
 import { acceptInvitation } from '@/service/group.api';
+import { useSnackbar } from '@/contexts/SnackBar.context';
 
 // REVIEW 기능 테스트 전 입니다
 export default function JoinTeamPage() {
   const { user } = useUser(true);
+  const { showSnackbar } = useSnackbar();
 
   const { formData, handleInputChange, errorMessage } = useForm({
     userEmail: user?.email || '',
@@ -19,10 +21,8 @@ export default function JoinTeamPage() {
 
   const { mutateAsync: postJoinGroup, isPending: isJoinGroup } = useMutation({
     mutationFn: acceptInvitation,
-    onSuccess: () => {
-      console.log('팀 참여 성공');
-    },
-    onError: (error) => console.error('팀 참여 실패:', error),
+    onSuccess: () => showSnackbar('팀 참여가 완료되었습니다.'),
+    onError: () => showSnackbar('팀 참여에 실패 하였습니다.', 'error'),
   });
 
   const handleSubmit = (e: React.FormEvent) => {

--- a/app/(auth)/layout.tsx
+++ b/app/(auth)/layout.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { usePathname } from 'next/navigation';
-import { useSession } from 'next-auth/react';
 
 import Container from '@/components/layout/Container';
 import OauthForm from '@/components/OauthForm';
@@ -13,8 +12,6 @@ interface ILayoutProps {
 export default function Layout({ children }: ILayoutProps) {
   const pathName = usePathname();
   const currentPath = pathName.split('/').pop();
-
-  const { status } = useSession();
 
   const pageTitles: Record<string, string> = {
     login: '로그인',
@@ -36,11 +33,9 @@ export default function Layout({ children }: ILayoutProps) {
       <div className="mx-auto w-pr-460 mo:w-full">
         {children}
         <div className="mt-pr-48 mo:mt-pr-25">
-          {currentPath &&
-            ['login', 'signup'].includes(currentPath) &&
-            status !== 'loading' && (
-              <OauthForm type={currentPath as 'login' | 'signup'} />
-            )}
+          {currentPath && ['login', 'signup'].includes(currentPath) && (
+            <OauthForm type={currentPath as 'login' | 'signup'} />
+          )}
         </div>
       </div>
     </Container>

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -4,7 +4,6 @@ import React, { useEffect, MouseEvent, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { useMutation } from '@tanstack/react-query';
-import { useSession } from 'next-auth/react';
 
 import { signIn } from '@/service/auth.api';
 import useForm from '@/hooks/useForm';
@@ -13,7 +12,6 @@ import InputField from '@/components/InputField/InputField';
 import Buttons from '@/components/Buttons';
 import useModalStore from '@/stores/modalStore';
 import ResetPassword from '@/components/modal/ResetPassword';
-import AuthLoading from '@/components/AuthLoading';
 import { useSnackbar } from '@/contexts/SnackBar.context';
 
 function LoginPage() {
@@ -23,10 +21,9 @@ function LoginPage() {
   });
 
   const route = useRouter();
-  const { user, reload, isAuthenticated } = useUser();
+  const { reload, user } = useUser();
   const { openModal } = useModalStore();
 
-  const { status } = useSession();
   const { showSnackbar } = useSnackbar();
 
   // STUB submit 후 로그인 에러 메시지
@@ -55,15 +52,10 @@ function LoginPage() {
     openModal(<ResetPassword />);
   };
 
-  // // STUB 로그인 성공 시
   useEffect(() => {
-    if (user) reload();
-  }, [user, reload]);
-
-  useEffect(() => {
-    if (isAuthenticated) {
+    if (user) {
       // STUB 로그인 후 가입된 그룹이 있을 때, 첫 번째 그룹으로 이동
-      if (user && user.memberships.length > 0) {
+      if (user.memberships.length > 0) {
         route.push(`/${user.memberships[0].groupId}`);
       } else {
         route.push(`/`);
@@ -71,9 +63,7 @@ function LoginPage() {
     } else {
       return;
     }
-  }, [user, route, isAuthenticated]);
-
-  if (status === 'loading') return <AuthLoading />;
+  }, [route, user]);
 
   // STUB 로그인 상태가 아닐 때
   return (

--- a/app/(auth)/reset-password/page.tsx
+++ b/app/(auth)/reset-password/page.tsx
@@ -5,8 +5,8 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import { useMutation } from '@tanstack/react-query';
 
 import { resetPassword } from '@/service/user.api';
+import { useSnackbar } from '@/contexts/SnackBar.context';
 import useForm from '@/hooks/useForm';
-// import useUser from '@/hooks/useUser';
 import InputField from '@/components/InputField/InputField';
 import Buttons from '@/components/Buttons';
 
@@ -17,6 +17,8 @@ export default function ResetPasswordPage() {
   // STUB 비밀번호 초기화 토큰 가져오기
   const searchParams = useSearchParams();
   const resetToken = searchParams.get('token');
+
+  const { showSnackbar } = useSnackbar();
 
   // STUB 비밀번호 초기화 폼
   const {
@@ -43,10 +45,10 @@ export default function ResetPasswordPage() {
     useMutation({
       mutationFn: resetPassword,
       onSuccess: () => {
-        alert('비밀번호가 성공적으로 변경되었습니다.');
+        showSnackbar('비밀번호가 성공적으로 변경되었습니다.');
         route.push('/login');
       },
-      onError: (error) => console.error('비밀번호 초기화 실패:', error),
+      onError: () => showSnackbar('비밀번호 초기화에 실패했습니다.', 'error'),
     });
 
   // STUB 비밀번호 초기화 폼 제출

--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -2,12 +2,14 @@
 
 import { useRouter } from 'next/navigation';
 import { useMutation } from '@tanstack/react-query';
+import { useEffect } from 'react';
 
 import { signUp } from '@/service/auth.api';
 import useForm from '@/hooks/useForm';
 import InputField from '@/components/InputField/InputField';
 import Buttons from '@/components/Buttons';
 import { useSnackbar } from '@/contexts/SnackBar.context';
+import useUser from '@/hooks/useUser';
 
 function SignupPage() {
   const { formData, handleInputChange, errorMessage } = useForm({
@@ -16,6 +18,8 @@ function SignupPage() {
     password: '',
     passwordConfirmation: '',
   });
+
+  const { user } = useUser();
 
   const route = useRouter();
 
@@ -36,6 +40,19 @@ function SignupPage() {
 
     postSignup(formData);
   };
+
+  useEffect(() => {
+    if (user) {
+      // STUB 로그인 후 가입된 그룹이 있을 때, 첫 번째 그룹으로 이동
+      if (user.memberships.length > 0) {
+        route.push(`/${user.memberships[0].groupId}`);
+      } else {
+        route.push(`/`);
+      }
+    } else {
+      return;
+    }
+  }, [route, user]);
 
   return (
     <form onSubmit={handleSubmit}>

--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -27,7 +27,7 @@ function SignupPage() {
       showSnackbar('회원가입이 완료 되었습니다.');
       route.push('/login');
     },
-    onError: () => showSnackbar('회원가입에 실패했습니다.', 'error'),
+    onError: () => showSnackbar('이미 사용중인 이메일입니다.', 'error'),
   });
 
   // 회원가입 버튼 클릭 시

--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -1,14 +1,13 @@
 'use client';
 
-import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { useMutation } from '@tanstack/react-query';
 
 import { signUp } from '@/service/auth.api';
 import useForm from '@/hooks/useForm';
-import useUser from '@/hooks/useUser';
 import InputField from '@/components/InputField/InputField';
 import Buttons from '@/components/Buttons';
+import { useSnackbar } from '@/contexts/SnackBar.context';
 
 function SignupPage() {
   const { formData, handleInputChange, errorMessage } = useForm({
@@ -20,17 +19,15 @@ function SignupPage() {
 
   const route = useRouter();
 
-  // 인증된 사용자인지 확인
-  const { isAuthenticated } = useUser();
+  const { showSnackbar } = useSnackbar();
 
   const { mutateAsync: postSignup, isPending: isSignup } = useMutation({
     mutationFn: signUp,
     onSuccess: () => {
-      alert('회원가입이 완료 되었습니다.');
-      console.log('회원가입 성공');
+      showSnackbar('회원가입이 완료 되었습니다.');
       route.push('/login');
     },
-    onError: () => console.log('회원가입 실패'),
+    onError: () => showSnackbar('회원가입에 실패했습니다.', 'error'),
   });
 
   // 회원가입 버튼 클릭 시
@@ -39,12 +36,6 @@ function SignupPage() {
 
     postSignup(formData);
   };
-
-  useEffect(() => {
-    if (isAuthenticated) {
-      route.push('/');
-    }
-  }, [isAuthenticated, route]);
 
   return (
     <form onSubmit={handleSubmit}>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,9 +1,8 @@
 'use client';
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+import dynamic from 'next/dynamic';
 import { SessionProvider } from 'next-auth/react';
-import { Session } from 'next-auth';
 
 import '@/styles/fonts.css';
 import '@/styles/globals.css';
@@ -21,12 +20,19 @@ import { TooltipProvider } from '@/components/ui/tooltip';
 import { SnackbarProvider } from '@/contexts/SnackBar.context';
 
 const queryClient = new QueryClient();
+
+const ReactQueryDevtools = dynamic(
+  () =>
+    import('@tanstack/react-query-devtools').then(
+      (mod) => mod.ReactQueryDevtools,
+    ),
+  { ssr: false },
+);
+
 export default function RootLayout({
   children,
-  session,
 }: Readonly<{
   children: React.ReactNode;
-  session?: Session;
 }>) {
   return (
     <html lang="ko">
@@ -39,7 +45,7 @@ export default function RootLayout({
             disableTransitionOnChange
           >
             <QueryClientProvider client={queryClient}>
-              <SessionProvider session={session}>
+              <SessionProvider refetchInterval={0}>
                 <TooltipProvider>
                   <SidebarProvider defaultOpen={false}>
                     <SnackbarProvider>

--- a/components/InputField/InputField.tsx
+++ b/components/InputField/InputField.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import { useSession } from 'next-auth/react';
 
 import { InputFieldProps } from '@/types/inputField.type';
 import useModalStore from '@/stores/modalStore';
@@ -40,10 +39,10 @@ export default function InputField({
   disabled = false,
   width = '',
   onChange,
+  sesstionStatus,
   ...props
 }: InputFieldProps) {
   const [showPassword, setShowPassword] = useState(false);
-  const { status } = useSession();
   const { openModal } = useModalStore();
 
   // --- fadeOut 처리를 위한 상태 ---
@@ -90,7 +89,7 @@ export default function InputField({
         />
         {type === 'password' &&
           (disabled ? (
-            status !== 'authenticated' && (
+            sesstionStatus !== 'authenticated' && (
               <div className="absolute right-pr-16 top-1/2 -translate-y-1/2">
                 <Buttons
                   text="변경하기"

--- a/components/OauthForm.tsx
+++ b/components/OauthForm.tsx
@@ -43,13 +43,13 @@ export default function OauthForm({ type }: { type: 'login' | 'signup' }) {
 
   const isExecuted = useRef(false);
 
-  // STUB 유저 정보가 없고, 구글 로그인 데이터가 있을 때
   useEffect(() => {
     if (!session || isExecuted.current) return;
 
     isExecuted.current = true;
 
     if (session?.googleIdToken) {
+      // STUB 유저 정보가 없고, 구글 로그인 데이터가 있을 때
       const googleFormData = {
         provider: 'GOOGLE',
         state: 'authenticated',
@@ -58,28 +58,21 @@ export default function OauthForm({ type }: { type: 'login' | 'signup' }) {
       };
 
       postOauthLogin(googleFormData);
-    }
-  }, [postOauthLogin, session]);
-
-  // STUB 유저 정보가 없고, 카카오 로그인 데이터가 있을 때, 로그인 처리가 되지 않았을 때(중복 로그인 방지)
-  useEffect(() => {
-    if (!session || isExecuted.current) return;
-
-    isExecuted.current = true;
-
-    if (!user && session && session.user && session.kakaoAccessToken) {
+    } else if (session?.kakaoAccessToken) {
+      // STUB 유저 정보가 없고, 카카오 로그인 데이터가 있을 때, 로그인 처리가 되지 않았을 때(중복 로그인 방지)
       const kakaoFormData = {
         id: session.id || 0,
         user: {
-          email: session.user.email || `${session.id}@kakao.com`,
-          nickname: `${session.user.name}${generateRandomNumber(5)}`,
-          image: session.user.image || '',
+          email: session?.user?.email || `${session?.id}@kakao.com`,
+          nickname: `${session?.user?.name}${generateRandomNumber(5)}`,
+          image: session?.user?.image || '',
         },
         accessToken: session.kakaoAccessToken, // 세션에 저장된 최신 토큰 사용
       };
+
       kakaoLogin(kakaoFormData, reload);
     }
-  }, [session, user, reload, kakaoLogin]);
+  }, [session, user]);
 
   return (
     <>

--- a/components/modal/DeleteAccount.tsx
+++ b/components/modal/DeleteAccount.tsx
@@ -1,54 +1,25 @@
 'use client';
 
-import { useMutation } from '@tanstack/react-query';
-import { signOut, useSession } from 'next-auth/react';
-
 import useModalStore from '@/stores/modalStore';
 import Buttons from '@/components/Buttons';
 import DangerIcon from '@/public/images/icon-danger.svg';
-import { deleteUser } from '@/service/user.api';
-import useUser from '@/hooks/useUser';
-import { revokeGoogleAccess, revokeKakaoAccess } from '@/service/auth.api';
-import { removeLoginProcessed, removeProfileUpdated } from '@/lib/kakaoStorage';
 
 /**
  * 회원 탈퇴 모달 컴포넌트.
  * 회원 탈퇴 버튼 클릭 시 회원 탈퇴 기능을 제공합니다.
  */
-export default function DeleteAccount() {
-  const { clear } = useUser();
+export default function DeleteAccount({
+  onClick,
+  isPending,
+}: {
+  onClick: () => void;
+  isPending: boolean;
+}) {
   const { closeModal } = useModalStore();
-  const session = useSession();
 
-  // STUB 회원 탈퇴 api mutate
-  const { mutate: deleteUserMutate, isPending } = useMutation({
-    mutationFn: deleteUser,
-    onSuccess: () => {
-      removeProfileUpdated();
-      removeLoginProcessed();
-      alert('회원탈퇴가 완료되었습니다.');
-      clear();
-    },
-    onError: () => alert('회원탈퇴에 실패했습니다.'),
-  });
-
-  const handleDeleteAccount = async () => {
-    // STUB 회원 탈퇴 api 호출
-    deleteUserMutate();
+  const handleOnClick = () => {
+    onClick();
     closeModal();
-
-    // STUB 구글 연동 해제
-    if (session.data?.googleAccessToken) {
-      await revokeGoogleAccess(session.data.googleAccessToken);
-    }
-
-    // STUB 카카오 연동 해제
-    if (session.data?.kakaoAccessToken) {
-      await revokeKakaoAccess(session.data?.kakaoAccessToken);
-    }
-
-    // STUB 세션 로그아웃
-    await signOut({ redirect: false });
   };
 
   return (
@@ -76,7 +47,7 @@ export default function DeleteAccount() {
         />
         <Buttons
           text="회원 탈퇴"
-          onClick={() => handleDeleteAccount()}
+          onClick={() => handleOnClick()}
           backgroundColor="danger"
           loading={isPending}
         />

--- a/components/modal/ResetPassword.tsx
+++ b/components/modal/ResetPassword.tsx
@@ -8,6 +8,7 @@ import InputField from '@/components/InputField/InputField';
 import useForm from '@/hooks/useForm';
 import { ResetPasswordEmailParams } from '@/types/user.type';
 import { resetPasswordEmail } from '@/service/user.api';
+import { useSnackbar } from '@/contexts/SnackBar.context';
 
 /**
  * 비밀번호 재설정 모달 컴포넌트.
@@ -15,11 +16,12 @@ import { resetPasswordEmail } from '@/service/user.api';
  */
 export default function ResetPassword() {
   const { closeModal } = useModalStore();
+  const { showSnackbar } = useSnackbar();
 
   const origin =
     typeof window !== 'undefined'
       ? window.location.origin
-      : 'http://localhost:3000';
+      : 'https://coworkers.netlify.app';
 
   const {
     formData: createResetUrl,
@@ -33,15 +35,16 @@ export default function ResetPassword() {
 
   const { mutate: resetPasswordMutate, isPending } = useMutation({
     mutationFn: resetPasswordEmail,
-    onSuccess: (message) => {
-      alert(message);
+    onSuccess: () => {
+      showSnackbar('비밀번호 재설정 링크를 보냈습니다. 이메일을 확인해주세요.');
       resetForm();
       closeModal();
     },
-    onError: (error) => {
-      alert('존재하지 않는 이메일 입니다.');
-      console.error('비밀번호 재설정 실패:', error);
-    },
+    onError: () =>
+      showSnackbar(
+        '존재하지 않는 이메일 입니다. 이메일을 확인해주세요.',
+        'error',
+      ),
   });
 
   return (

--- a/hooks/useKakao.ts
+++ b/hooks/useKakao.ts
@@ -8,6 +8,7 @@ import {
 } from '@/lib/kakaoStorage';
 import { signIn, signUp } from '@/service/auth.api';
 import { updateUser } from '@/service/user.api';
+import { useSnackbar } from '@/contexts/SnackBar.context';
 
 interface IKakaoLogin {
   id: number;
@@ -17,6 +18,7 @@ interface IKakaoLogin {
 const useKakaoLogin = () => {
   // STUB 중복 로그인 방지 플래그
   const signInExecutedRef = useRef(false);
+  const { showSnackbar } = useSnackbar();
 
   const kakaoLogin = useCallback(
     async ({ id, user: userData }: IKakaoLogin, reload: () => void) => {
@@ -52,14 +54,13 @@ const useKakaoLogin = () => {
               email: userEmail,
               password: userPassword,
             });
-            console.log('[카카오] 로그인 완료');
+            showSnackbar('카카오 로그인이 완료되었습니다.');
             setLoginProcessed();
 
             if (!getProfileUpdated()) {
               await updateUser({
                 image: image || '',
               });
-              console.log('프로필 업데이트 완료');
               setProfileUpdated();
             }
           }

--- a/stories/modal.stories.tsx
+++ b/stories/modal.stories.tsx
@@ -64,7 +64,12 @@ const Template: StoryFn = () => {
     openModal(<DeleteTask title="dd" onClick={() => handleAddTask} />);
   };
   const handleOpenDeleteAccount = () => {
-    openModal(<DeleteAccount />);
+    openModal(
+      <DeleteAccount
+        onClick={() => console.log('회원탈퇴 클릭')}
+        isPending={false}
+      />,
+    );
   };
   const handleOpenChangePassword = () => {
     openModal(<ChangePassword />);

--- a/types/inputField.type.ts
+++ b/types/inputField.type.ts
@@ -11,6 +11,7 @@ export interface InputFieldProps
   width?: string;
   onClickButton?: () => void;
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  sesstionStatus?: string;
 }
 
 export interface TextareaFieldProps


### PR DESCRIPTION
## 관련 이슈

<!-- 연관된 이슈 번호를 작성해주세요 예 #15 -->

close #209 

## 요약

<!-- 작업 내용에 대해 간단히 설명해주세요 -->
- 회원가입, 패스워드 재설정, 팀 참가, 팀 생성, 패스워드재설정 모달, useKakao 훅 내부 console.log를 스낵바로 변경
- 세션 중복 호출 방지 로직 추가

## 변경 사항 설명

<!-- 구현한 내용에 대해 자세한 내용을 작성해 주세요 -->
- 작업 페이지 api console.log 부분 스낵바로 교체 진행 했습니다
- 세션 중복 호출 방지를 위해 useSession을 컴포넌트 내부에서 호출하는것이 아닌 props를 통해 받아서 상태를 공유 할 수 있도록 수정했습니다.
- 카카오,구글 로그인 useEffect 통합 및 불필요한 디펜더시 제거를 통해 최적화 진행했습니다
- 로그인 페이지에 수정된 useUser에 맞게 조건분기 수정하였습니다
- 회원가입 에러 시 리턴되는 문구를 변경하였습니다.
<!-- 추가적으로 리뷰를 원하는 부분을 알려주세요 -->

## 주의 사항
- 기존의 로그인에서 로딩스피너 부분을 제거하였습니다.
- 해당 부분을 스캘레톤으로 진행하려했으나, 스캘레톤으로 작성하니, 너무 많은 리렌더링으로 인한 에러가 발생하여, 진행하지않았습니다.
- 로그인 페이지가 로드 되기전에 세션 검증 때문에 OauthForm이 먼저 노출되는 경우가 있습니다.(이는 세션 중복 호출 되는 부분때문에 useSession 최소화를 위해 조건에서 제외 했습니다)
- 인터넷 환경에 따라서 OauthForm이 먼저 노출되는 경우라서 이부분을 어떻게 처리해야하는지에 대해서는 추가 이슈 생성하여 진행하겠습니다.
- 로그인페이지에서 useEffect 통합 및 디펜더시 제거로 인해 소셜 로그인이 비정상적으로 동작할까봐 테스트를 진행하였으나, 구글 로그인은 문제가 없음을 확인했지만 카카오 로그인의 경우 제 카카오 이메일로는 로그인확인이 되지않아서 대신 테스트 해주시고 문제 있으면 코멘트 주시길 바랍니다.
- 그리고 모달에서 관리되는 기능들은 리팩토링을 통해 페이지 내부에서 관리하여 콜백함수를 인자로 전달하여 확인할 수 있도록 수정 예정이며, 페이지 가독성 증진을 위해 UI와 기능부분을 훅을 통해 분리할 예정입니다(MVVM (Model-View-ViewModel) 디자인 패턴 적용)
- 회원탈퇴 후 콘솔에 [에러](https://github.com/fe11-part4-team3/coworkers/pull/213#discussion_r1948426649)가 발생합니다. 이 부분은 별도의 이슈에서 추가 진행 할 예정이니, 해당 이슈에서는 무시해주시면 감사하겠습니다..!
