### PR TITLE
#215 useForm의 changedFields, errorMessage 초기화 로직 변경

### DIFF
--- a/hooks/useForm.ts
+++ b/hooks/useForm.ts
@@ -51,10 +51,10 @@ const useForm = <T extends Record<string, FormValue>>(initialValues: T) => {
   const [formData, setFormData] = useState<T>(initialValues);
   const [errorMessage, setErrorMessage] = useState<
     Partial<Record<keyof T, string>>
-  >({});
+  >(initializeValues(initialValues, ''));
   const [changedFields, setChangedFields] = useState<
     Partial<Record<keyof T, boolean>>
-  >({});
+  >(initializeValues(initialValues, false));
 
   // input 디바운스된 검증 함수
   const debouncedValidateField = useDebounce(

--- a/hooks/useForm.ts
+++ b/hooks/useForm.ts
@@ -6,6 +6,19 @@ import useDebounce from '@/hooks/useDebounce';
 
 export type FormValue = string | number | File | '';
 
+/**
+ * 특정 객체의 `key`와 동일한 `key`를 공유하는 객체를 생성하는 함수
+ * @param values `key`를 공유할 원본 객체
+ * @param initValue 프로퍼티에 들어갈 초기값
+ * @returns 초기화 된 객체
+ * @example
+ * ```
+ * const A = { a : value1,  b : value2  };
+ * const B = initialValues(A, false);
+ * console.log(B)
+ * // {a : false, b : false}
+ * ```
+ */
 const initializeValues = <T extends Record<string, FormValue>, U>(
   values: T,
   initValue: U,

--- a/hooks/useForm.ts
+++ b/hooks/useForm.ts
@@ -135,8 +135,9 @@ const useForm = <T extends Record<string, FormValue>>(initialValues: T) => {
         ? { ...initialValues, ...newValues }
         : initialValues;
       setFormData(updatedInitialValues);
-      setChangedFields({});
-      setErrorMessage({});
+      setChangedFields(initializeValues(initialValues, false));
+      setErrorMessage(initializeValues(initialValues, ''));
+      handleClearPreview();
     },
     [initialValues],
   );

--- a/hooks/useForm.ts
+++ b/hooks/useForm.ts
@@ -6,6 +6,19 @@ import useDebounce from '@/hooks/useDebounce';
 
 export type FormValue = string | number | File | '';
 
+const initializeValues = <T extends Record<string, FormValue>, U>(
+  values: T,
+  initValue: U,
+): Partial<Record<keyof T, U>> => {
+  return Object.keys(values).reduce(
+    (acc, key) => {
+      acc[key as keyof T] = initValue;
+      return acc;
+    },
+    {} as Partial<Record<keyof T, U>>,
+  );
+};
+
 /**
  * useForm
  * @param initialValues 초기값


### PR DESCRIPTION
## 관련 이슈

close #215

## 변경 사항 설명

### 초기화 객체 생성 함수 구현

`initialValues`의 `key`를 복사해 새로운 객체를 생성하는 함수를 구현했습니다.

**사용법**
```ts
 const A = { a : value1,  b : value2  };
 const B = initializeValues(A, false);
 console.log(B)
 // {a : false, b : false}
 ```

### changedFields, errorMessage를 초기화

`initializeValues` 함수를 사용해 `changedFields`, `errorMessage`를 초기화 합니다.

기존에는 `useForm` 마운트 시 `changedFields`와 `errorMessage`는 빈 객체인 `{ }`로 초기화 되었습니다.

이는 몇몇 불편한 부분이 있어 이를 개선하기 위해 초기화 로직을 수정했습니다.
