### PR TITLE
#211 팀페이지의 팀 수정하기 기능 구현

### DIFF
--- a/app/[teamId]/(index)/GroupEditModal.tsx
+++ b/app/[teamId]/(index)/GroupEditModal.tsx
@@ -1,0 +1,39 @@
+import Buttons from '@/components/Buttons';
+import InputField from '@/components/InputField/InputField';
+import Profile from '@/components/Profile/Profile';
+import useModalStore from '@/stores/modalStore';
+
+export default function GroupEditModal() {
+  const { closeModal } = useModalStore();
+
+  return (
+    <div>
+      <h2 className="mb-pr-16 text-center text-16m">팀 수정하기</h2>
+      <form className="flex flex-col items-center gap-pr-16">
+        <Profile variant="group" isEdit />
+        <InputField
+          type="text"
+          name="name"
+          placeholder="팀 이름을 입력해주세요."
+          label="팀 이름"
+          required
+        />
+      </form>
+      <div className="modal-button-wrapper">
+        <Buttons
+          text="닫기"
+          onClick={closeModal}
+          border="primary"
+          backgroundColor="white"
+          textColor="primary"
+        />
+        <Buttons
+          text="변경하기"
+          type="submit"
+          loading={false}
+          disabled={false}
+        />
+      </div>
+    </div>
+  );
+}

--- a/app/[teamId]/(index)/GroupEditModal.tsx
+++ b/app/[teamId]/(index)/GroupEditModal.tsx
@@ -23,7 +23,6 @@ export default function GroupEditModal({ group, onEdit }: GroupEditModalProps) {
     handleInputChange,
     handleFileChange,
     changedFields,
-    resetForm,
   } = useForm({
     name: group.name,
     image: group.image || '',
@@ -40,8 +39,6 @@ export default function GroupEditModal({ group, onEdit }: GroupEditModalProps) {
       formData,
       mutate: onEdit,
     });
-
-    resetForm();
   };
 
   return (

--- a/app/[teamId]/(index)/GroupEditModal.tsx
+++ b/app/[teamId]/(index)/GroupEditModal.tsx
@@ -1,39 +1,87 @@
+import { FormEvent } from 'react';
+
 import Buttons from '@/components/Buttons';
 import InputField from '@/components/InputField/InputField';
 import Profile from '@/components/Profile/Profile';
 import useModalStore from '@/stores/modalStore';
+import useForm from '@/hooks/useForm';
+import { IGroupDetail } from '@/types/group.type';
+import updatePayloadSubmit from '@/utils/updatePayload';
 
-export default function GroupEditModal() {
+import { _UpdateGroupParams } from './TeamPage.type';
+
+interface GroupEditModalProps {
+  group: IGroupDetail;
+  onEdit: (params: _UpdateGroupParams) => void;
+}
+
+export default function GroupEditModal({ group, onEdit }: GroupEditModalProps) {
   const { closeModal } = useModalStore();
+  const {
+    formData,
+    preview,
+    handleInputChange,
+    handleFileChange,
+    changedFields,
+    resetForm,
+  } = useForm({
+    name: group.name,
+    image: group.image || '',
+  });
+
+  const disabledForm = !Object.values(changedFields).some((value) => value);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (disabledForm) return;
+
+    await updatePayloadSubmit({
+      changedFields: changedFields,
+      formData,
+      mutate: onEdit,
+    });
+
+    resetForm();
+  };
 
   return (
     <div>
       <h2 className="mb-pr-16 text-center text-16m">팀 수정하기</h2>
-      <form className="flex flex-col items-center gap-pr-16">
-        <Profile variant="group" isEdit />
+      <form
+        className="flex flex-col items-center gap-pr-16"
+        onSubmit={handleSubmit}
+      >
+        <Profile
+          variant="group"
+          image={preview || formData.image}
+          onSelectFile={handleFileChange}
+          isEdit
+        />
         <InputField
           type="text"
           name="name"
-          placeholder="팀 이름을 입력해주세요."
           label="팀 이름"
+          value={formData.name}
+          onChange={handleInputChange}
+          placeholder="팀 이름을 입력해주세요."
           required
         />
+        <div className="modal-button-wrapper w-full">
+          <Buttons
+            text="닫기"
+            onClick={closeModal}
+            border="primary"
+            backgroundColor="white"
+            textColor="primary"
+          />
+          <Buttons
+            text="변경하기"
+            type="submit"
+            loading={false}
+            disabled={disabledForm}
+          />
+        </div>
       </form>
-      <div className="modal-button-wrapper">
-        <Buttons
-          text="닫기"
-          onClick={closeModal}
-          border="primary"
-          backgroundColor="white"
-          textColor="primary"
-        />
-        <Buttons
-          text="변경하기"
-          type="submit"
-          loading={false}
-          disabled={false}
-        />
-      </div>
     </div>
   );
 }

--- a/app/[teamId]/(index)/GroupHeader.tsx
+++ b/app/[teamId]/(index)/GroupHeader.tsx
@@ -5,28 +5,30 @@ import Image from 'next/image';
 import IconGear from '@/public/images/icon-gear.svg';
 import DropDown from '@/components/DropDown';
 import useThemeMode from '@/hooks/useThemeMode';
-import { RoleType } from '@/types/group.type';
+import { IGroupDetail, RoleType } from '@/types/group.type';
 import useModalStore from '@/stores/modalStore';
 
 import GroupEditModal from './GroupEditModal';
+import { _UpdateGroupParams } from './TeamPage.type';
 
 interface GroupHeaderProps {
   role: RoleType;
-  name: string;
+  group: IGroupDetail;
+  onEdit: (params: _UpdateGroupParams) => void;
 }
 
 //TODO 썸네일 이미지 추가
-export default function GroupHeader({ role, name }: GroupHeaderProps) {
+export default function GroupHeader({ role, group, onEdit }: GroupHeaderProps) {
   const theme = useThemeMode();
   const { openModal } = useModalStore();
 
   const handleClickEdit = () => {
-    openModal(<GroupEditModal />);
+    openModal(<GroupEditModal group={group} onEdit={onEdit} />);
   };
 
   return (
     <header className="flex max-h-pr-64 max-w-pr-1200 items-center justify-between rounded-pr-12 border border-[#F8FAFC1A] bg-[--t-primary-dark-10] px-pr-20">
-      <h2 className="text-20b text-primary">{name}</h2>
+      <h2 className="text-20b text-primary">{group.name}</h2>
       <div className="flex items-center gap-pr-20">
         <Image
           src={

--- a/app/[teamId]/(index)/GroupHeader.tsx
+++ b/app/[teamId]/(index)/GroupHeader.tsx
@@ -6,20 +6,23 @@ import IconGear from '@/public/images/icon-gear.svg';
 import DropDown from '@/components/DropDown';
 import useThemeMode from '@/hooks/useThemeMode';
 import { RoleType } from '@/types/group.type';
+import useModalStore from '@/stores/modalStore';
+
+import GroupEditModal from './GroupEditModal';
 
 interface GroupHeaderProps {
   role: RoleType;
   name: string;
-  // onClick: () => void;
 }
 
 //TODO 썸네일 이미지 추가
-export default function GroupHeader({
-  role,
-  name,
-  // onClick,
-}: GroupHeaderProps) {
+export default function GroupHeader({ role, name }: GroupHeaderProps) {
   const theme = useThemeMode();
+  const { openModal } = useModalStore();
+
+  const handleClickEdit = () => {
+    openModal(<GroupEditModal />);
+  };
 
   return (
     <header className="flex max-h-pr-64 max-w-pr-1200 items-center justify-between rounded-pr-12 border border-[#F8FAFC1A] bg-[--t-primary-dark-10] px-pr-20">
@@ -41,7 +44,7 @@ export default function GroupHeader({
               <IconGear className="transition-all hover:rotate-90 hover:scale-110 focus:rotate-90 data-[state=open]:rotate-90 data-[state=open]:scale-110" />
             }
             items={[
-              { text: '수정하기', onClick: () => {} },
+              { text: '수정하기', onClick: handleClickEdit },
               { text: '삭제하기', onClick: () => {} },
             ]}
           />

--- a/app/[teamId]/(index)/TeamPage.type.ts
+++ b/app/[teamId]/(index)/TeamPage.type.ts
@@ -1,19 +1,17 @@
 import { UpdateGroupParams } from '@/types/group.type';
+import {
+  CreateTaskListParams,
+  DeleteTaskListParams,
+  UpdateTaskListParams,
+} from '@/types/taskList.type';
 
 type _UpdateGroupParams = Omit<UpdateGroupParams, 'id'>;
 
-interface _CreateTaskListParams {
-  name: string;
-}
+type _CreateTaskListParams = Omit<CreateTaskListParams, 'groupId'>;
 
-interface _UpdateTaskListParams {
-  id: number;
-  name: string;
-}
+type _UpdateTaskListParams = Omit<UpdateTaskListParams, 'groupId'>;
 
-interface _DeleteTaskListParams {
-  id: number;
-}
+type _DeleteTaskListParams = Omit<DeleteTaskListParams, 'groupId'>;
 
 export type {
   _UpdateGroupParams,

--- a/app/[teamId]/(index)/TeamPage.type.ts
+++ b/app/[teamId]/(index)/TeamPage.type.ts
@@ -1,3 +1,7 @@
+import { UpdateGroupParams } from '@/types/group.type';
+
+type _UpdateGroupParams = Omit<UpdateGroupParams, 'id'>;
+
 interface _CreateTaskListParams {
   name: string;
 }
@@ -12,6 +16,7 @@ interface _DeleteTaskListParams {
 }
 
 export type {
+  _UpdateGroupParams,
   _CreateTaskListParams,
   _UpdateTaskListParams,
   _DeleteTaskListParams,

--- a/app/[teamId]/(index)/page.tsx
+++ b/app/[teamId]/(index)/page.tsx
@@ -47,22 +47,11 @@ export default function TeamPage() {
     initialData: [],
   });
 
-  const { mutate: onCreate } = useMutation({
+  const { mutate: onCreateTaskList } = useMutation({
     mutationFn: (params: _CreateTaskListParams) => _createTaskList(params),
     onSuccess: () => refetch(),
     onError: (error) => alert(error),
   });
-  const { mutate: onEdit } = useMutation({
-    mutationFn: (params: _UpdateTaskListParams) => _updateTaskList(params),
-    onSuccess: ({ id }) => refetchById(id),
-    onError: (error) => alert(error),
-  });
-  const { mutate: onDelete } = useMutation({
-    mutationFn: (params: _DeleteTaskListParams) => _deleteTaskList(params),
-    onSuccess: ({ id }) => removeById(id),
-    onError: (error) => alert(error),
-  });
-
   const _createTaskList = (params: _CreateTaskListParams) => {
     if (!group) throw new Error('목록을 생성할 팀이 없습니다');
     if (role !== 'ADMIN')
@@ -70,6 +59,11 @@ export default function TeamPage() {
     return createTaskList({ groupId: group.id, ...params });
   };
 
+  const { mutate: onEditTaskList } = useMutation({
+    mutationFn: (params: _UpdateTaskListParams) => _updateTaskList(params),
+    onSuccess: ({ id }) => refetchById(id),
+    onError: (error) => alert(error),
+  });
   const _updateTaskList = (params: _UpdateTaskListParams) => {
     if (!group) throw new Error('수정할 목록의 팀이 없습니다');
     if (role !== 'ADMIN')
@@ -77,6 +71,11 @@ export default function TeamPage() {
     return updateTaskList({ groupId: group.id, ...params });
   };
 
+  const { mutate: onDeleteTaskList } = useMutation({
+    mutationFn: (params: _DeleteTaskListParams) => _deleteTaskList(params),
+    onSuccess: ({ id }) => removeById(id),
+    onError: (error) => alert(error),
+  });
   const _deleteTaskList = async (params: _DeleteTaskListParams) => {
     if (!group) throw new Error('삭제할 목록의 팀이 없습니다');
     if (role !== 'ADMIN')
@@ -97,9 +96,9 @@ export default function TeamPage() {
         <GroupTaskListWrapper
           role={role}
           taskLists={taskLists}
-          onCreate={onCreate}
-          onEdit={onEdit}
-          onDelete={onDelete}
+          onCreate={onCreateTaskList}
+          onEdit={onEditTaskList}
+          onDelete={onDeleteTaskList}
         />
         <GroupReport tasks={tasks} taskLists={taskLists} />
         <GroupMemberList role={role} groupId={group.id} members={members} />

--- a/app/[teamId]/(index)/page.tsx
+++ b/app/[teamId]/(index)/page.tsx
@@ -25,12 +25,14 @@ import {
   _UpdateTaskListParams,
 } from './TeamPage.type';
 import GroupReport from './GroupReport';
+import useModalStore from '@/stores/modalStore';
 
 export default function TeamPage() {
   const { memberships, reload } = useUser(true);
   const { teamId } = useParams();
   const { group, members, refetch, isPending } = useGroup(Number(teamId));
   const { taskLists, refetchById, removeById } = useTaskLists();
+  const { closeModal } = useModalStore();
 
   const currentMembership = memberships?.find(
     (membership) => membership.groupId === group?.id,
@@ -51,6 +53,7 @@ export default function TeamPage() {
   const { mutate: onEditGroup } = useMutation({
     mutationFn: (params: _UpdateGroupParams) => _updateGroup(params),
     onSuccess: () => {
+      closeModal();
       reload();
       refetch();
     },

--- a/app/[teamId]/(index)/page.tsx
+++ b/app/[teamId]/(index)/page.tsx
@@ -14,6 +14,7 @@ import {
 import NotFound from '@/app/404/NotFound';
 import useTaskLists from '@/hooks/useTaskLists';
 import { getTasksInGroup, updateGroup } from '@/service/group.api';
+import useModalStore from '@/stores/modalStore';
 
 import GroupHeader from './GroupHeader';
 import GroupMemberList from './GroupMemberList';
@@ -25,7 +26,6 @@ import {
   _UpdateTaskListParams,
 } from './TeamPage.type';
 import GroupReport from './GroupReport';
-import useModalStore from '@/stores/modalStore';
 
 export default function TeamPage() {
   const { memberships, reload } = useUser(true);


### PR DESCRIPTION
## 관련 이슈

close #211 

## 변경 사항 설명

### 팀 수정하기 기능 구현

팀 수정하기 기능을 구현했습니다.

팀 페이지에서 `톱니 버튼` -> `수정하기`로 사용 가능합니다.

![image](https://github.com/user-attachments/assets/7d9f1b5f-4c46-4446-aa60-ba787b5d620d)

요구사항에서는 수정하기를 클릭하면 팀 수정하기 페이지로 이동합니다.

하지만 이는 불필요한 리소스 낭비로 느껴저 그냥 팀페이지에서 모달로 팀 수정이 가능하게 구현했습니다.

|![image](https://github.com/user-attachments/assets/63bf50c2-1938-44cc-a57f-5401db9eb557)|![image](https://github.com/user-attachments/assets/69cf2127-feb2-435d-a8e2-b68673c6b5ef)|
|---|---|
|요구사항|변경사항|


