### PR TITLE
#226 useParams 구조분해할당 경고문 및 Image 컴포넌트 경고문 에러 수정

### DIFF
--- a/app/[teamId]/(index)/page.tsx
+++ b/app/[teamId]/(index)/page.tsx
@@ -29,7 +29,6 @@ import {
 import GroupReport from './GroupReport';
 
 export default function TeamPage() {
-  const { memberships } = useUser(true);
   const params = useParams();
   const safeParams = React.useMemo(() => params, [params]);
   const { teamId } = safeParams;

--- a/app/[teamId]/(index)/page.tsx
+++ b/app/[teamId]/(index)/page.tsx
@@ -2,6 +2,7 @@
 
 import { useParams } from 'next/navigation';
 import { useMutation, useQuery } from '@tanstack/react-query';
+import React from 'react';
 
 import Container from '@/components/layout/Container';
 import useUser from '@/hooks/useUser';
@@ -27,7 +28,9 @@ import GroupReport from './GroupReport';
 
 export default function TeamPage() {
   const { memberships } = useUser(true);
-  const { teamId } = useParams();
+  const params = useParams();
+  const safeParams = React.useMemo(() => params, [params]);
+  const { teamId } = safeParams;
   const { group, members, refetch, isPending } = useGroup(Number(teamId));
   const { taskLists, refetchById, removeById } = useTaskLists();
 

--- a/app/boards/[articleId]/page.tsx
+++ b/app/boards/[articleId]/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useParams } from 'next/navigation';
+import React from 'react';
 
 import Container from '@/components/layout/Container';
 
@@ -8,7 +9,9 @@ import ArticleDetail from './ArticleDetail';
 import CommentContainer from './CommentContainer';
 
 function ArticleDetailPage() {
-  const { articleId } = useParams();
+  const params = useParams();
+  const safeParams = React.useMemo(() => params, [params]);
+  const { articleId } = safeParams;
 
   return (
     <Container>

--- a/app/boards/editarticle/[articleId]/page.tsx
+++ b/app/boards/editarticle/[articleId]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ChangeEvent, useCallback, useEffect, useState } from 'react';
+import React, { ChangeEvent, useCallback, useEffect, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import { useMutation } from '@tanstack/react-query';
 
@@ -33,7 +33,9 @@ function EditArticlePage() {
   const [prevValue, setPrevValue] = useState(INITIAL_VALUES);
 
   const router = useRouter();
-  const { articleId } = useParams();
+  const params = useParams();
+  const safeParams = React.useMemo(() => params, [params]);
+  const { articleId } = safeParams;
 
   const isEditChanged =
     formData.title === prevValue.title &&

--- a/components/Empty/Empty.tsx
+++ b/components/Empty/Empty.tsx
@@ -40,7 +40,9 @@ function Empty({
           src="/images/img-noTeam.png"
           alt="No data"
           className="object-contain"
+          sizes="(max-width: 320px) 100vw, (max-width: 480px) 100vw, (max-width: 768px) 100vw, (max-width: 1024px) 100vw, 100vw"
           fill
+          priority
         />
       </div>
 

--- a/components/layout/Header/Headers.tsx
+++ b/components/layout/Header/Headers.tsx
@@ -27,7 +27,9 @@ function Headers() {
   const queryClient = useQueryClient();
   const deviceType = useDeviceType();
   const router = useRouter();
-  const { teamId } = useParams();
+  const params = useParams();
+  const safeParams = React.useMemo(() => params, [params]);
+  const { teamId } = safeParams;
   const groupId = teamId ? Number(teamId) : null;
   const { user, groups, isPending, clear: clearUser } = useUser();
   const { clear: clearGroup } = useGroup(Number(teamId));

--- a/components/layout/Header/Logo.tsx
+++ b/components/layout/Header/Logo.tsx
@@ -8,9 +8,9 @@ function Logo() {
       <Image
         src="/images/img-Logo.svg"
         alt="로고"
-        layout="intrinsic"
         width={158}
         height={32}
+        priority
       />
     </Link>
   );


### PR DESCRIPTION
## 관련 이슈

<!-- 연관된 이슈 번호를 작성해주세요 예 #15 -->

close #226 

## 요약

- ✅ 동적 라우트에서 사용되는 useParams 구조분해할당 한 부분 wrapper로 경고문 해결
- ✅ 로그인 페이지, 헤더에서 발생하는 Image 태그 경고문 해결

<!-- 작업 내용에 대해 간단히 설명해주세요 -->

## 변경 사항 설명

- `Headers`, `/[teamId/(index)`, `/boards/[articleld]`, `/boards/editarticle/[articleld]` 해당 페이지에서 `useParams`를 구조분해할당하여 사용하는 부분을 `wrapper`로 감싸서 업데이트 된 리액트에 맞춰 수정 진행했습니다.
- Empty, Logo 컴포넌트에서 발생하는 Image 태그 속성 경고문 수정하여, 해결 하였습니다.

<!-- 구현한 내용에 대해 자세한 내용을 작성해 주세요 -->
<!-- 추가적으로 리뷰를 원하는 부분을 알려주세요 -->

## 주의 사항
- 리액트가 업데이트 되면서 useParams를 구조분해할당하여 사용하지않고 wrapper로 한번 감싸서 사용하는 방식으로 변경 되었습니다.
- 해당 경고는 다이나믹 라우트에서 발생되는 이슈이며, 앞으로 작업하실때 useParams를 사용하실 일이 있으시다면 wrapper로 감싸서 사용해주시길 바랍니다.
