### PR TITLE
#230 팀 삭제하기 기능 구현

### DIFF
--- a/app/[teamId]/(index)/GroupDeleteModal.tsx
+++ b/app/[teamId]/(index)/GroupDeleteModal.tsx
@@ -1,0 +1,44 @@
+import Buttons from '@/components/Buttons';
+import useModalStore from '@/stores/modalStore';
+import DangerIcon from '@/public/images/icon-danger.svg';
+
+interface GroupDeleteModalProps {
+  onDelete: () => void;
+}
+
+export default function GroupDeleteModal({ onDelete }: GroupDeleteModalProps) {
+  const { closeModal } = useModalStore();
+
+  return (
+    <>
+      <DangerIcon
+        width={24}
+        height={24}
+        className="mx-auto mb-pr-16"
+        onClick={closeModal}
+      />
+      <div className="modal-title-wrapper">
+        <h2 className="modal-title">팀 삭제를 진행하시겠어요?</h2>
+        <p className="modal-subTitle">
+          모든 할 일 목록은 자동으로 삭제되고, <br />
+          모든 멤버들은 팀에서 나가집니다.
+        </p>
+      </div>
+      <div className="modal-button-wrapper">
+        <Buttons
+          text="닫기"
+          onClick={closeModal}
+          border="secondary"
+          backgroundColor="white"
+          textColor="default"
+        />
+        <Buttons
+          text="삭제하기"
+          onClick={onDelete}
+          backgroundColor="danger"
+          loading={false}
+        />
+      </div>
+    </>
+  );
+}

--- a/app/[teamId]/(index)/GroupHeader.tsx
+++ b/app/[teamId]/(index)/GroupHeader.tsx
@@ -15,15 +15,27 @@ interface GroupHeaderProps {
   role: RoleType;
   group: IGroupDetail;
   onEdit: (params: _UpdateGroupParams) => void;
+  onDelete: () => void;
 }
 
 //TODO 썸네일 이미지 추가
-export default function GroupHeader({ role, group, onEdit }: GroupHeaderProps) {
+export default function GroupHeader({
+  role,
+  group,
+  onEdit,
+  onDelete,
+}: GroupHeaderProps) {
   const theme = useThemeMode();
   const { openModal } = useModalStore();
 
   const handleClickEdit = () => {
     openModal(<GroupEditModal group={group} onEdit={onEdit} />);
+  };
+
+  const handleClickDelete = () => {
+    if (confirm('팀을 삭제 하시겠습니까?')) {
+      onDelete();
+    }
   };
 
   return (
@@ -47,7 +59,7 @@ export default function GroupHeader({ role, group, onEdit }: GroupHeaderProps) {
             }
             items={[
               { text: '수정하기', onClick: handleClickEdit },
-              { text: '삭제하기', onClick: () => {} },
+              { text: '삭제하기', onClick: handleClickDelete },
             ]}
           />
         )}

--- a/app/[teamId]/(index)/GroupHeader.tsx
+++ b/app/[teamId]/(index)/GroupHeader.tsx
@@ -10,6 +10,7 @@ import useModalStore from '@/stores/modalStore';
 
 import GroupEditModal from './GroupEditModal';
 import { _UpdateGroupParams } from './TeamPage.type';
+import GroupDeleteModal from './GroupDeleteModal';
 
 interface GroupHeaderProps {
   role: RoleType;
@@ -33,9 +34,7 @@ export default function GroupHeader({
   };
 
   const handleClickDelete = () => {
-    if (confirm('팀을 삭제 하시겠습니까?')) {
-      onDelete();
-    }
+    openModal(<GroupDeleteModal onDelete={onDelete} />);
   };
 
   return (

--- a/app/[teamId]/(index)/page.tsx
+++ b/app/[teamId]/(index)/page.tsx
@@ -27,6 +27,7 @@ import {
   _UpdateTaskListParams,
 } from './TeamPage.type';
 import GroupReport from './GroupReport';
+import { useSnackbar } from '@/contexts/SnackBar.context';
 
 export default function TeamPage() {
   const router = useRouter();
@@ -42,6 +43,7 @@ export default function TeamPage() {
   } = useGroup(Number(teamId));
   const { taskLists, refetchById, removeById, removeAll } = useTaskLists();
   const { closeModal } = useModalStore();
+  const { showSnackbar } = useSnackbar();
 
   const currentMembership = memberships?.find(
     (membership) => membership.groupId === group?.id,
@@ -82,8 +84,9 @@ export default function TeamPage() {
       removeAll();
       refetchUser();
       refetchGroup();
+      showSnackbar('팀을 삭제했습니다.');
     },
-    onError: (error) => alert(error),
+    onError: (error) => showSnackbar(error.message),
   });
   const _deleteGroup = () => {
     if (!group) throw new Error('삭제할 팀이 없습니다');

--- a/app/[teamId]/(index)/page.tsx
+++ b/app/[teamId]/(index)/page.tsx
@@ -16,6 +16,7 @@ import NotFound from '@/app/404/NotFound';
 import useTaskLists from '@/hooks/useTaskLists';
 import useModalStore from '@/stores/modalStore';
 import { deleteGroup, getTasksInGroup, updateGroup } from '@/service/group.api';
+import { useSnackbar } from '@/contexts/SnackBar.context';
 
 import GroupHeader from './GroupHeader';
 import GroupMemberList from './GroupMemberList';
@@ -27,7 +28,6 @@ import {
   _UpdateTaskListParams,
 } from './TeamPage.type';
 import GroupReport from './GroupReport';
-import { useSnackbar } from '@/contexts/SnackBar.context';
 
 export default function TeamPage() {
   const router = useRouter();

--- a/app/[teamId]/(index)/page.tsx
+++ b/app/[teamId]/(index)/page.tsx
@@ -75,10 +75,10 @@ export default function TeamPage() {
     mutationFn: () => _deleteGroup(),
     onSuccess: () => {
       closeModal();
+      router.push('/');
       removeAll();
       refetchUser();
       refetchGroup();
-      router.push('/');
     },
     onError: (error) => alert(error),
   });

--- a/hooks/useTaskLists.ts
+++ b/hooks/useTaskLists.ts
@@ -14,7 +14,7 @@ import { useQueries, useQueryClient } from '@tanstack/react-query';
  */
 export default function useTaskLists() {
   const queryClient = useQueryClient();
-  const { taskLists, setTaskLists } = useGroupStore();
+  const { taskLists, setTaskLists, clearStore } = useGroupStore();
 
   const queries = useQueries({
     queries:
@@ -37,6 +37,9 @@ export default function useTaskLists() {
   const refetchById = async (id: number) =>
     await queryClient.refetchQueries({ queryKey: ['taskList', id] });
 
+  const refetchAll = async () =>
+    await queryClient.refetchQueries({ queryKey: ['taskList'] });
+
   const removeById = (id: number) => {
     const next = taskLists?.filter((taskList) => taskList.id !== id);
     if (next) {
@@ -45,15 +48,18 @@ export default function useTaskLists() {
     }
   };
 
-  const refetchAll = async () =>
-    await queryClient.refetchQueries({ queryKey: ['taskList'] });
+  const removeAll = () => {
+    clearStore();
+    queryClient.removeQueries({ queryKey: ['taskLists'] });
+  };
 
   return {
     taskLists: data.length > 0 ? data : null,
     isPending: !!taskLists && isPending,
     error,
     refetchById,
-    removeById,
     refetchAll,
+    removeById,
+    removeAll,
   };
 }

--- a/service/group.api.ts
+++ b/service/group.api.ts
@@ -3,6 +3,7 @@ import {
   CreateGroupParams,
   CreateGroupResponse,
   DeleteGroupParams,
+  DeleteGroupResponse,
   DeleteMemberParams,
   GetGroupParams,
   GetInvitationParams,
@@ -39,9 +40,11 @@ const updateGroup = async ({
   return response.data;
 };
 
-const deleteGroup = async ({ id }: DeleteGroupParams): Promise<boolean> => {
+const deleteGroup = async ({
+  id,
+}: DeleteGroupParams): Promise<DeleteGroupResponse> => {
   const response = await instance.delete(`/groups/${id}`);
-  return response.status === 204;
+  return { success: response.status === 204, id };
 };
 
 /**

--- a/types/group.type.ts
+++ b/types/group.type.ts
@@ -66,6 +66,11 @@ interface CreateGroupResponse {
   id: number;
 }
 
+interface DeleteGroupResponse {
+  success: boolean;
+  id: number;
+}
+
 interface GetMemberParams {
   id: number;
   memberUserId: number;
@@ -107,6 +112,7 @@ export type {
   DeleteGroupParams,
   CreateGroupParams,
   CreateGroupResponse,
+  DeleteGroupResponse,
   GetMemberParams,
   DeleteMemberParams,
   GetInvitationParams,


### PR DESCRIPTION
## 관련 이슈

close #230 

## 변경 사항 설명

### 팀 삭제하기 기능 구현

팀 삭제하기 기능을 구현했습니다.

팀 삭제 이후는 마땅히 이동할 위치를 모르겠어서 랜딩페이지로 이동하게 만들었습니다.

더 좋은 의견이 있으시다면 언제든 말씀 부탁드립니다.

모달 같은 경우, 시간에는 삭제와 관련된 모달이 없어서 @JUYOUNG0728 님이 만들어 두신 회원 탈퇴 모달 코드를 긁어와 만들었습니다.