### PR TITLE
#221 input 정상 입력 시에도 툴팁이 노출되는 버그 수정

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -17,10 +17,13 @@ import AuthLoading from '@/components/AuthLoading';
 import { useSnackbar } from '@/contexts/SnackBar.context';
 
 function LoginPage() {
-  const { formData, handleInputChange, errorMessage } = useForm({
+  const initialValues = {
     email: '',
     password: '',
-  });
+  };
+
+  const { formData, handleInputChange, changedFields, errorMessage } =
+    useForm(initialValues);
 
   const route = useRouter();
   const { user, reload, isAuthenticated } = useUser();
@@ -75,6 +78,16 @@ function LoginPage() {
 
   if (status === 'loading') return <AuthLoading />;
 
+  const requiredFields = Object.keys(initialValues);
+
+  const hasDisabled =
+    requiredFields.some(
+      (field) => !changedFields[field as keyof typeof changedFields],
+    ) ||
+    requiredFields.some(
+      (field) => errorMessage[field as keyof typeof errorMessage] !== '',
+    );
+
   // STUB 로그인 상태가 아닐 때
   return (
     <>
@@ -121,10 +134,7 @@ function LoginPage() {
           text="로그인"
           type="submit"
           className="mt-pr-40"
-          disabled={
-            isLogin ||
-            !(errorMessage.email === '' && errorMessage.password === '')
-          }
+          disabled={hasDisabled}
           loading={isLogin}
         />
       </form>

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -20,8 +20,13 @@ function LoginPage() {
     password: '',
   };
 
-  const { formData, handleInputChange, changedFields, errorMessage } =
-    useForm(initialValues);
+  const {
+    formData,
+    handleInputChange,
+    changedFields,
+    handleInputBlur,
+    errorMessage,
+  } = useForm(initialValues);
 
   const route = useRouter();
   const { reload, user } = useUser();
@@ -93,6 +98,7 @@ function LoginPage() {
               handleInputChange(e);
               setHasLoginError('');
             }}
+            onBlur={handleInputBlur}
             errorMessage={hasLoginError ? hasLoginError : errorMessage.email}
             placeholder="이메일을 입력해주세요."
             required
@@ -104,6 +110,7 @@ function LoginPage() {
             autoComplete="current-password"
             value={formData.password}
             onChange={handleInputChange}
+            onBlur={handleInputBlur}
             errorMessage={errorMessage.password}
             placeholder="비밀번호를 입력해주세요."
             required

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -14,12 +14,12 @@ import useModalStore from '@/stores/modalStore';
 import ResetPassword from '@/components/modal/ResetPassword';
 import { useSnackbar } from '@/contexts/SnackBar.context';
 
-function LoginPage() {
-  const initialValues = {
-    email: '',
-    password: '',
-  };
+const initialValues = {
+  email: '',
+  password: '',
+};
 
+function LoginPage() {
   const {
     formData,
     handleInputChange,

--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -11,14 +11,14 @@ import Buttons from '@/components/Buttons';
 import { useSnackbar } from '@/contexts/SnackBar.context';
 import useUser from '@/hooks/useUser';
 
-function SignupPage() {
-  const initialValues = {
-    email: '',
-    nickname: '',
-    password: '',
-    passwordConfirmation: '',
-  };
+const initialValues = {
+  email: '',
+  nickname: '',
+  password: '',
+  passwordConfirmation: '',
+};
 
+function SignupPage() {
   const { formData, handleInputChange, changedFields, errorMessage } =
     useForm(initialValues);
 

--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -11,12 +11,15 @@ import InputField from '@/components/InputField/InputField';
 import Buttons from '@/components/Buttons';
 
 function SignupPage() {
-  const { formData, handleInputChange, errorMessage } = useForm({
+  const initialValues = {
     email: '',
     nickname: '',
     password: '',
     passwordConfirmation: '',
-  });
+  };
+
+  const { formData, handleInputChange, changedFields, errorMessage } =
+    useForm(initialValues);
 
   const route = useRouter();
 
@@ -45,6 +48,16 @@ function SignupPage() {
       route.push('/');
     }
   }, [isAuthenticated, route]);
+
+  const requiredFields = Object.keys(initialValues);
+
+  const hasDisabled =
+    requiredFields.some(
+      (field) => !changedFields[field as keyof typeof changedFields],
+    ) ||
+    requiredFields.some(
+      (field) => errorMessage[field as keyof typeof errorMessage] !== '',
+    );
 
   return (
     <form onSubmit={handleSubmit}>
@@ -100,15 +113,7 @@ function SignupPage() {
         text="회원가입"
         type="submit"
         className="mt-pr-40"
-        disabled={
-          isSignup ||
-          !(
-            errorMessage.email === '' &&
-            errorMessage.nickname === '' &&
-            errorMessage.password === '' &&
-            errorMessage.passwordConfirmation === ''
-          )
-        }
+        disabled={hasDisabled}
         loading={isSignup}
       />
     </form>

--- a/components/InputField/InputField.tsx
+++ b/components/InputField/InputField.tsx
@@ -39,6 +39,7 @@ export default function InputField({
   disabled = false,
   width = '',
   onChange,
+  onBlur,
   sesstionStatus,
   ...props
 }: InputFieldProps) {
@@ -84,6 +85,7 @@ export default function InputField({
           placeholder={placeholder}
           disabled={disabled}
           onChange={onChange}
+          onBlur={onBlur}
           className={`px-pr-16 py-pr-14.5 mo:py-pr-13.5 ${errorMessage && 'border-s-danger'} ${!disabled && !errorMessage && 'hover:border-i-hover'} ${inputStyled}`}
           {...props}
         />

--- a/hooks/useForm.ts
+++ b/hooks/useForm.ts
@@ -39,7 +39,16 @@ const useForm = <T extends Record<string, FormValue>>(initialValues: T) => {
         updatedFormData,
         initialValues,
       );
-      setErrorMessage((prevErr) => ({ ...prevErr, ...fieldErrors }));
+      setErrorMessage((prevErr) => ({
+        ...prevErr,
+        [key]: fieldErrors[key] || '',
+      }));
+
+      // 유효성 검사 후 changedFields 업데이트
+      setChangedFields((prevChanged) => ({
+        ...prevChanged,
+        [key]: value !== initialValues[key],
+      }));
     },
     500,
   );
@@ -58,12 +67,6 @@ const useForm = <T extends Record<string, FormValue>>(initialValues: T) => {
 
         // 새 formData
         const updatedFormData = { ...prev, [key]: value };
-
-        // 변경된 필드 표시
-        setChangedFields((prevChanged) => {
-          const isChanged = value !== initialValues[key];
-          return { ...prevChanged, [key]: isChanged };
-        });
 
         // 즉시 validateField를 부르는 대신, 디바운스된 검증 함수를 호출
         debouncedValidateField(key, value, updatedFormData);
@@ -111,7 +114,7 @@ const useForm = <T extends Record<string, FormValue>>(initialValues: T) => {
   useEffect(() => {
     setErrorMessage((prevErr) => ({
       ...prevErr,
-      image: fileError,
+      image: fileError || '',
     }));
   }, [fileError]);
 

--- a/hooks/useForm.ts
+++ b/hooks/useForm.ts
@@ -43,6 +43,7 @@ const initializeValues = <T extends Record<string, FormValue>, U>(
  * @returns resetForm 초기화 함수
  * @returns setChangedFields 변경된 필드 설정 함수
  * @returns handleInputChange 입력값 변경 핸들러
+ * @returns handleInputBlur 입력값 블러 핸들러
  * @returns handleFileChange 파일 변경 핸들러
  * @returns handleClearImage 파일 초기화 핸들러
  * @returns handleClearPreview 미리보기 초기화 핸들러
@@ -78,6 +79,30 @@ const useForm = <T extends Record<string, FormValue>>(initialValues: T) => {
     },
     500,
   );
+
+  const handleInputBlur = (
+    e: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement>,
+  ) => {
+    const { name, value } = e.target;
+    const key = name as keyof T;
+
+    // 디바운스 카운트가 끝나기전에 포커스를 이동한다면, 바로 검증 함수를 호출
+    const updatedFormData = { ...formData, [key]: value };
+    const fieldErrors = validateField(
+      key,
+      value,
+      updatedFormData,
+      initialValues,
+    );
+    setErrorMessage((prevErr) => ({
+      ...prevErr,
+      [key]: fieldErrors[key] || '',
+    }));
+    setChangedFields((prevChanged) => ({
+      ...prevChanged,
+      [key]: value !== initialValues[key],
+    }));
+  };
 
   // 입력값 변경 핸들러 (formData는 즉시 업데이트하되, 검증은 디바운스)
   const handleInputChange = useCallback(
@@ -167,6 +192,7 @@ const useForm = <T extends Record<string, FormValue>>(initialValues: T) => {
     resetForm,
     setChangedFields,
     handleInputChange,
+    handleInputBlur,
     handleFileChange,
     handleClearImage,
   };


### PR DESCRIPTION
## 관련 이슈

<!-- 연관된 이슈 번호를 작성해주세요 예 #15 -->

close #221 

## 요약

<!-- 작업 내용에 대해 간단히 설명해주세요 -->
- 로그인,회원가입 버튼 활성화 조건 변경
- useForm, InputField에 onBlur 핸들러 추가

## 변경 사항 설명

<!-- 구현한 내용에 대해 자세한 내용을 작성해 주세요 -->
<!-- 추가적으로 리뷰를 원하는 부분을 알려주세요 -->
- useForm에 change 이벤트 발생 여부 상태를 관리하는 함수를 디바운싱과 동기화 시켜, 입력이 완료 된 후에 필드 변경 상태 업데이트를 진행하도록 변경했습니다.
- useForm 훅이 변경되면서 버튼 활성화 조건을 수정하여, 입력이 되지않았을때도 버튼 활성화 되었던 버그 수정했습니다.
- 인풋 필드에 onBlur를 추가하여, 디바운싱 카운트가 끝나기도전에 포커싱 아웃이 되었다면, 디바운스 즉시 중단하도록 수정하여, 에러메세지가 즉시 초기화 되도록 했습니다.

## 주의 사항
- 재현님께서 남겨주신 https://github.com/fe11-part4-team3/coworkers/issues/221#issuecomment-2648018601 해당 버그는 끝내 확인이 불가능해서, 배포 후 배포 환경에서 추가 테스트 해봐야할것같습니다.
- 우선 이전에 발현되었던 버그는 개선이 되어 PR 올립니다.
