### PR TITLE
팀페이지에 멤버가 아닌 사용자가 접속이 가능한 문제 해결

### DIFF
--- a/app/[teamId]/layout.tsx
+++ b/app/[teamId]/layout.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import useGroup from '@/hooks/useGroup';
-import useUser from '@/hooks/useUser';
 import { useParams, useRouter } from 'next/navigation';
 import { useEffect, useMemo } from 'react';
+
+import useGroup from '@/hooks/useGroup';
+import useUser from '@/hooks/useUser';
 
 export default function RootLayout({
   children,

--- a/app/[teamId]/layout.tsx
+++ b/app/[teamId]/layout.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import useGroup from '@/hooks/useGroup';
+import useUser from '@/hooks/useUser';
+import { useParams, useRouter } from 'next/navigation';
+import { useEffect, useMemo } from 'react';
+
+export default function RootLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  const router = useRouter();
+  const params = useParams();
+  const safeParams = useMemo(() => params, [params]);
+  const { teamId } = safeParams;
+
+  const { memberships } = useUser();
+  const { group, isPending } = useGroup(Number(teamId));
+
+  const currentMembership = memberships?.find(
+    (membership) => membership.groupId === group?.id,
+  );
+
+  useEffect(() => {
+    if (group && !isPending && !currentMembership) router.push('/');
+  }, [group, isPending, currentMembership]);
+
+  if (!group && isPending) return null;
+
+  if (group && !currentMembership) return null;
+
+  return <>{children}</>;
+}


### PR DESCRIPTION
## 관련 이슈

close #240 

## 변경 사항 설명

### 문제

저희 백엔드 문제로 팀 멤버가 아닌 사용자가 요청을 보내도 서버가 팀 데이터를 응답으로 보내줍니다.

요청을 막을려면 생각보다 많은 작업이 필요해보입니다. 그래서 해당 작업은 최적화 단계에서 진행하겠습니다.

우선 요청은 보내되, 멤버가 아닐 경우 랜딩 페이지로 리다이렉트 하도록 만들었습니다.
