### PR TITLE
자유게시판 리스트 페이지 테블릿, 모바일 해상도 UI 틀어짐 수정

### DIFF
--- a/app/boards/ArticleList.tsx
+++ b/app/boards/ArticleList.tsx
@@ -93,6 +93,7 @@ function ArticleList({ keyword }: { keyword: string | undefined }) {
                     duration: 0.5,
                     delay: 0.1,
                   }}
+                  className="tamo:w-full"
                 >
                   <ArticleCard
                     articleData={article}


### PR DESCRIPTION
## 관련 이슈

close #244 

## 요약

자유게시판 리스트 페이지 테블릿, 모바일 해상도에서 게시글 카드 배열이 틀어지는 현상 수정하였습니다.

### Tablet
<img width="741" alt="스크린샷 2025-02-12 21 12 27" src="https://github.com/user-attachments/assets/63569439-7df4-4ed9-9b94-28cc675dacb5" />

### Mobile
<img width="538" alt="스크린샷 2025-02-12 21 12 35" src="https://github.com/user-attachments/assets/98f84980-a094-456d-885b-7e4daca0bb70" />
