### PR TITLE
#232 모달이 없던 기능들에  공용모달 적용

### DIFF
--- a/app/[teamId]/(index)/DeleteTaskListModal.tsx
+++ b/app/[teamId]/(index)/DeleteTaskListModal.tsx
@@ -11,10 +11,7 @@ interface DeleteTaskListModal {
 export default function DeleteTaskListModal({ onDelete }: DeleteTaskListModal) {
   const { closeModal } = useModalStore();
 
-  const handleOnClick = () => {
-    onDelete();
-    closeModal();
-  };
+  const handleOnClick = () => onDelete();
 
   return (
     <>

--- a/app/[teamId]/(index)/DeleteTaskListModal.tsx
+++ b/app/[teamId]/(index)/DeleteTaskListModal.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import useModalStore from '@/stores/modalStore';
+import Buttons from '@/components/Buttons';
+import DangerIcon from '@/public/images/icon-danger.svg';
+
+interface DeleteTaskListModal {
+  onDelete: () => void;
+}
+
+export default function DeleteTaskListModal({ onDelete }: DeleteTaskListModal) {
+  const { closeModal } = useModalStore();
+
+  const handleOnClick = () => {
+    onDelete();
+    closeModal();
+  };
+
+  return (
+    <>
+      <DangerIcon
+        width={24}
+        height={24}
+        className="mx-auto mb-pr-16"
+        onClick={closeModal}
+      />
+      <div className="modal-title-wrapper">
+        <h2 className="modal-title">목록 삭제를 진행하시겠어요?</h2>
+        <p className="modal-subTitle">
+          할 일 목록이 삭제되고, <br />
+          목록에 존재하던 모든 할 일도 삭제됩니다.
+        </p>
+      </div>
+      <div className="modal-button-wrapper">
+        <Buttons
+          text="닫기"
+          onClick={closeModal}
+          border="secondary"
+          backgroundColor="white"
+          textColor="default"
+        />
+        <Buttons
+          text="삭제"
+          onClick={() => handleOnClick()}
+          backgroundColor="danger"
+        />
+      </div>
+    </>
+  );
+}

--- a/app/[teamId]/(index)/EditTaskListModal.tsx
+++ b/app/[teamId]/(index)/EditTaskListModal.tsx
@@ -5,10 +5,7 @@ import { FormEvent } from 'react';
 import InputField from '@/components/InputField/InputField';
 import Buttons from '@/components/Buttons';
 import CloseButton from '@/components/modal/ModalCloseButton';
-import {
-  _CreateTaskListParams,
-  _UpdateTaskListParams,
-} from '@/app/[teamId]/(index)/TeamPage.type';
+import { _UpdateTaskListParams } from '@/app/[teamId]/(index)/TeamPage.type';
 import useForm from '@/hooks/useForm';
 import { ITaskList } from '@/types/taskList.type';
 

--- a/app/[teamId]/(index)/EditTaskListModal.tsx
+++ b/app/[teamId]/(index)/EditTaskListModal.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import InputField from '@/components/InputField/InputField';
+import Buttons from '@/components/Buttons';
+import CloseButton from '@/components/modal/ModalCloseButton';
+import {
+  _CreateTaskListParams,
+  _UpdateTaskListParams,
+} from '@/app/[teamId]/(index)/TeamPage.type';
+import useForm from '@/hooks/useForm';
+import { FormEvent } from 'react';
+import { ITaskList } from '@/types/taskList.type';
+
+interface EditTaskListProps {
+  taskList: ITaskList;
+  onEdit: (params: _UpdateTaskListParams) => void;
+}
+
+/**
+ * 할 일 목록 수정 모달 컴포넌트.
+ *
+ * @param props.taskList 할 일 목록 객체
+ * @param props.onEdit - 할 일 목록 수정 함수
+ */
+
+export default function EditTaskListModal({
+  taskList,
+  onEdit,
+}: EditTaskListProps) {
+  const { formData, changedFields, errorMessage, handleInputChange } = useForm({
+    name: taskList.name,
+  });
+
+  const validation = changedFields.name && !errorMessage.name;
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    onEdit({ id: taskList.id, ...formData });
+  };
+
+  return (
+    <>
+      <CloseButton />
+      <div className="modal-title-wrapper">
+        <h2 className="modal-title">할 일 목록</h2>
+      </div>
+      <form onSubmit={handleSubmit}>
+        <InputField
+          name="name"
+          value={formData.name}
+          onChange={handleInputChange}
+          placeholder="목록 명을 입력해주세요."
+          errorMessage={errorMessage.name}
+        />
+        <div className="modal-button-wrapper">
+          <Buttons text="수정하기" type="submit" disabled={!validation} />
+        </div>
+      </form>
+    </>
+  );
+}

--- a/app/[teamId]/(index)/EditTaskListModal.tsx
+++ b/app/[teamId]/(index)/EditTaskListModal.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { FormEvent } from 'react';
+
 import InputField from '@/components/InputField/InputField';
 import Buttons from '@/components/Buttons';
 import CloseButton from '@/components/modal/ModalCloseButton';
@@ -8,7 +10,6 @@ import {
   _UpdateTaskListParams,
 } from '@/app/[teamId]/(index)/TeamPage.type';
 import useForm from '@/hooks/useForm';
-import { FormEvent } from 'react';
 import { ITaskList } from '@/types/taskList.type';
 
 interface EditTaskListProps {

--- a/app/[teamId]/(index)/GroupTaskList.tsx
+++ b/app/[teamId]/(index)/GroupTaskList.tsx
@@ -11,6 +11,7 @@ import DropDown from '@/components/DropDown';
 import { MouseEvent, useRef } from 'react';
 import useModalStore from '@/stores/modalStore';
 import EditTaskListModal from './EditTaskListModal';
+import DeleteTaskListModal from './DeleteTaskListModal';
 
 type IPointColorClasses = {
   [key in PointColorType]: string;
@@ -62,8 +63,9 @@ export default function GroupTaskList({
   };
 
   const handleClickDelete = () => {
-    const flag = confirm(`${taskList.name}을(를) 삭제 하시겠습니다?`);
-    if (flag) onDelete({ id: taskList.id });
+    openModal(
+      <DeleteTaskListModal onDelete={() => onDelete({ id: taskList.id })} />,
+    );
   };
 
   return (

--- a/app/[teamId]/(index)/GroupTaskList.tsx
+++ b/app/[teamId]/(index)/GroupTaskList.tsx
@@ -9,6 +9,8 @@ import { PointColorType } from './GroupTaskListWrapper';
 import TaskProgressBadge from './TaskProgressBadge';
 import DropDown from '@/components/DropDown';
 import { MouseEvent, useRef } from 'react';
+import useModalStore from '@/stores/modalStore';
+import EditTaskListModal from './EditTaskListModal';
 
 type IPointColorClasses = {
   [key in PointColorType]: string;
@@ -41,6 +43,7 @@ export default function GroupTaskList({
 }: GroupTaskListProps) {
   const router = useRouter();
   const dropdownRef = useRef<HTMLDivElement>(null);
+  const { openModal } = useModalStore();
 
   const handleClickTaskList = (event: MouseEvent<HTMLDivElement>) => {
     if (dropdownRef.current?.contains(event.target as Node)) {
@@ -55,8 +58,7 @@ export default function GroupTaskList({
   };
 
   const handleClickEdit = () => {
-    const name = prompt('목록 명을 입력해주세요');
-    if (name) onEdit({ id: taskList.id, name });
+    openModal(<EditTaskListModal taskList={taskList} onEdit={onEdit} />);
   };
 
   const handleClickDelete = () => {

--- a/app/[teamId]/(index)/GroupTaskList.tsx
+++ b/app/[teamId]/(index)/GroupTaskList.tsx
@@ -1,15 +1,15 @@
 import { useRouter } from 'next/navigation';
+import { MouseEvent, useRef } from 'react';
 
 import { ITaskList } from '@/types/taskList.type';
 import { RoleType } from '@/types/group.type';
 import createUrlString from '@/utils/createUrlString';
+import DropDown from '@/components/DropDown';
+import useModalStore from '@/stores/modalStore';
 
 import { _DeleteTaskListParams, _UpdateTaskListParams } from './TeamPage.type';
 import { PointColorType } from './GroupTaskListWrapper';
 import TaskProgressBadge from './TaskProgressBadge';
-import DropDown from '@/components/DropDown';
-import { MouseEvent, useRef } from 'react';
-import useModalStore from '@/stores/modalStore';
 import EditTaskListModal from './EditTaskListModal';
 import DeleteTaskListModal from './DeleteTaskListModal';
 

--- a/app/[teamId]/(index)/GroupTaskList.tsx
+++ b/app/[teamId]/(index)/GroupTaskList.tsx
@@ -1,6 +1,5 @@
 import { useRouter } from 'next/navigation';
 
-import KebabDropDown from '@/components/KebabDropDown';
 import { ITaskList } from '@/types/taskList.type';
 import { RoleType } from '@/types/group.type';
 import createUrlString from '@/utils/createUrlString';
@@ -8,6 +7,8 @@ import createUrlString from '@/utils/createUrlString';
 import { _DeleteTaskListParams, _UpdateTaskListParams } from './TeamPage.type';
 import { PointColorType } from './GroupTaskListWrapper';
 import TaskProgressBadge from './TaskProgressBadge';
+import DropDown from '@/components/DropDown';
+import { MouseEvent, useRef } from 'react';
 
 type IPointColorClasses = {
   [key in PointColorType]: string;
@@ -39,8 +40,13 @@ export default function GroupTaskList({
   onDelete,
 }: GroupTaskListProps) {
   const router = useRouter();
+  const dropdownRef = useRef<HTMLDivElement>(null);
 
-  const handleClickTaskList = () => {
+  const handleClickTaskList = (event: MouseEvent<HTMLDivElement>) => {
+    if (dropdownRef.current?.contains(event.target as Node)) {
+      return;
+    }
+
     const url = createUrlString({
       pathname: [taskList.groupId, 'tasklist'],
       queryParams: { id: taskList.id },
@@ -69,10 +75,17 @@ export default function GroupTaskList({
         <div className="flex items-center gap-pr-4">
           <TaskProgressBadge tasks={taskList.tasks} />
           {role === 'ADMIN' && (
-            <KebabDropDown
-              onEdit={handleClickEdit}
-              onDelete={handleClickDelete}
-            />
+            <div className="size-pr-16">
+              <DropDown
+                ref={dropdownRef}
+                trigger={<button className="icon-kebab absolute" />}
+                items={[
+                  { text: '수정하기', onClick: handleClickEdit },
+                  { text: '삭제하기', onClick: handleClickDelete },
+                ]}
+                width="w-pr-120"
+              />
+            </div>
           )}
         </div>
       </div>

--- a/app/[teamId]/(index)/GroupTaskListWrapper.tsx
+++ b/app/[teamId]/(index)/GroupTaskListWrapper.tsx
@@ -8,6 +8,8 @@ import {
   _DeleteTaskListParams,
   _UpdateTaskListParams,
 } from './TeamPage.type';
+import useModalStore from '@/stores/modalStore';
+import AddTaskList from '@/components/modal/AddTaskList';
 
 export type PointColorType =
   | 'purple'
@@ -43,10 +45,10 @@ export default function GroupTaskListWrapper({
   onEdit,
   onDelete,
 }: GroupTaskListWrapperProps) {
-  const handleClickCreate = () => {
-    const name = prompt('목록 명을 입력해주세요');
-    if (name) onCreate({ name });
-  };
+  const { openModal } = useModalStore();
+
+  const handleClickCreate = () =>
+    openModal(<AddTaskList onCreate={onCreate} />);
 
   return (
     <div className="flex flex-col gap-pr-16">

--- a/app/[teamId]/(index)/GroupTaskListWrapper.tsx
+++ b/app/[teamId]/(index)/GroupTaskListWrapper.tsx
@@ -1,6 +1,8 @@
 import IconPlus from '@/public/images/icon-plus.svg';
 import { ITaskList } from '@/types/taskList.type';
 import { RoleType } from '@/types/group.type';
+import useModalStore from '@/stores/modalStore';
+import AddTaskList from '@/components/modal/AddTaskList';
 
 import GroupTaskList from './GroupTaskList';
 import {
@@ -8,8 +10,6 @@ import {
   _DeleteTaskListParams,
   _UpdateTaskListParams,
 } from './TeamPage.type';
-import useModalStore from '@/stores/modalStore';
-import AddTaskList from '@/components/modal/AddTaskList';
 
 export type PointColorType =
   | 'purple'

--- a/app/[teamId]/(index)/page.tsx
+++ b/app/[teamId]/(index)/page.tsx
@@ -26,6 +26,7 @@ import {
   _UpdateTaskListParams,
 } from './TeamPage.type';
 import GroupReport from './GroupReport';
+import { useSnackbar } from '@/contexts/SnackBar.context';
 
 export default function TeamPage() {
   const { memberships, reload } = useUser(true);
@@ -33,6 +34,7 @@ export default function TeamPage() {
   const { group, members, refetch, isPending } = useGroup(Number(teamId));
   const { taskLists, refetchById, removeById } = useTaskLists();
   const { closeModal } = useModalStore();
+  const { showSnackbar } = useSnackbar();
 
   const currentMembership = memberships?.find(
     (membership) => membership.groupId === group?.id,
@@ -67,7 +69,11 @@ export default function TeamPage() {
 
   const { mutate: onCreateTaskList } = useMutation({
     mutationFn: (params: _CreateTaskListParams) => _createTaskList(params),
-    onSuccess: () => refetch(),
+    onSuccess: () => {
+      closeModal();
+      refetch();
+      showSnackbar('할 일 목록을 생성했습니다.');
+    },
     onError: (error) => alert(error),
   });
   const _createTaskList = (params: _CreateTaskListParams) => {

--- a/app/[teamId]/(index)/page.tsx
+++ b/app/[teamId]/(index)/page.tsx
@@ -16,6 +16,7 @@ import NotFound from '@/app/404/NotFound';
 import useTaskLists from '@/hooks/useTaskLists';
 import useModalStore from '@/stores/modalStore';
 import { deleteGroup, getTasksInGroup, updateGroup } from '@/service/group.api';
+import { useSnackbar } from '@/contexts/SnackBar.context';
 
 import GroupHeader from './GroupHeader';
 import GroupMemberList from './GroupMemberList';
@@ -27,7 +28,6 @@ import {
   _UpdateTaskListParams,
 } from './TeamPage.type';
 import GroupReport from './GroupReport';
-import { useSnackbar } from '@/contexts/SnackBar.context';
 
 export default function TeamPage() {
   const router = useRouter();

--- a/app/[teamId]/(index)/page.tsx
+++ b/app/[teamId]/(index)/page.tsx
@@ -86,7 +86,7 @@ export default function TeamPage() {
       refetchGroup();
       showSnackbar('팀을 삭제했습니다.');
     },
-    onError: (error) => showSnackbar(error.message),
+    onError: (error) => showSnackbar(error.message, 'error'),
   });
   const _deleteGroup = () => {
     if (!group) throw new Error('삭제할 팀이 없습니다');
@@ -101,7 +101,7 @@ export default function TeamPage() {
       refetchGroup();
       showSnackbar('할 일 목록을 생성했습니다.');
     },
-    onError: (error) => alert(error),
+    onError: (error) => showSnackbar(error.message, 'error'),
   });
   const _createTaskList = (params: _CreateTaskListParams) => {
     if (!group) throw new Error('목록을 생성할 팀이 없습니다');
@@ -112,8 +112,11 @@ export default function TeamPage() {
 
   const { mutate: onEditTaskList } = useMutation({
     mutationFn: (params: _UpdateTaskListParams) => _updateTaskList(params),
-    onSuccess: ({ id }) => refetchById(id),
-    onError: (error) => alert(error),
+    onSuccess: ({ id }) => {
+      refetchById(id);
+      showSnackbar('할 일 목록을 수정했습니다.');
+    },
+    onError: (error) => showSnackbar(error.message, 'error'),
   });
   const _updateTaskList = (params: _UpdateTaskListParams) => {
     if (!group) throw new Error('수정할 목록의 팀이 없습니다');
@@ -124,8 +127,11 @@ export default function TeamPage() {
 
   const { mutate: onDeleteTaskList } = useMutation({
     mutationFn: (params: _DeleteTaskListParams) => _deleteTaskList(params),
-    onSuccess: ({ id }) => removeById(id),
-    onError: (error) => alert(error),
+    onSuccess: ({ id }) => {
+      removeById(id);
+      showSnackbar('할 일 목록을 삭제했습니다.');
+    },
+    onError: (error) => showSnackbar(error.message, 'error'),
   });
   const _deleteTaskList = async (params: _DeleteTaskListParams) => {
     if (!group) throw new Error('삭제할 목록의 팀이 없습니다');

--- a/app/[teamId]/(index)/page.tsx
+++ b/app/[teamId]/(index)/page.tsx
@@ -114,6 +114,7 @@ export default function TeamPage() {
     mutationFn: (params: _UpdateTaskListParams) => _updateTaskList(params),
     onSuccess: ({ id }) => {
       refetchById(id);
+      closeModal();
       showSnackbar('할 일 목록을 수정했습니다.');
     },
     onError: (error) => showSnackbar(error.message, 'error'),
@@ -129,6 +130,7 @@ export default function TeamPage() {
     mutationFn: (params: _DeleteTaskListParams) => _deleteTaskList(params),
     onSuccess: ({ id }) => {
       removeById(id);
+      closeModal();
       showSnackbar('할 일 목록을 삭제했습니다.');
     },
     onError: (error) => showSnackbar(error.message, 'error'),

--- a/components/DropDown.tsx
+++ b/components/DropDown.tsx
@@ -6,12 +6,14 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from './ui/dropdown-menu';
+import { Ref } from 'react';
 
 type DropDownItem =
   | { text: string; href: string; onClick?: never }
   | { text: string; href?: never; onClick: () => void };
 
 export interface DropDownProps {
+  ref?: Ref<HTMLDivElement>;
   trigger: React.ReactNode;
   items: DropDownItem[];
   width?: string;
@@ -19,6 +21,7 @@ export interface DropDownProps {
 
 /**
  * @description DropDown 컴포넌트
+ * @param {Ref<HTMLDivElement>} props.ref 드롭다운 컨텐츠의 ref
  * @param {React.ReactNode} props.trigger - 드롭다운 트리거
  * @param {DropDownItem[]} props.items - 드롭다운 아이템
  * @param {string} props.width - 드롭다운 너비
@@ -34,8 +37,26 @@ export interface DropDownProps {
  *   ]}
  *   width="w-pr-100"
  *   />
+ *
+ * @example
+ * ```ts
+ *  const ref = useRef<HTMLDivElement>(null);
+ *
+ * // 드롭 다운 클릭 시 즉시 반환
+ *  const handleClick = (event: MouseEvent<HTMLDivElement>) => {
+ *    if (ref.current?.contains(event.target as Node)) return;
+ *    ...
+ *  };
+ *  ...
+ * return <DropDown ref={ref} ... />
+ * ```
  */
-export default function DropDown({ trigger, items, width }: DropDownProps) {
+export default function DropDown({
+  ref,
+  trigger,
+  items,
+  width,
+}: DropDownProps) {
   const dropDownItemStyled = 'py-pr-14 mo:py-pr-12 dropdown-item text-14';
 
   return (
@@ -43,6 +64,7 @@ export default function DropDown({ trigger, items, width }: DropDownProps) {
       <DropdownMenu>
         <DropdownMenuTrigger asChild>{trigger}</DropdownMenuTrigger>
         <DropdownMenuContent
+          ref={ref}
           className={`mt-pr-8 w-auto overflow-hidden rounded-xl border bg-b-secondary p-0 text-center text-14 text-t-default ${width}`}
           align="end"
         >

--- a/components/DropDown.tsx
+++ b/components/DropDown.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import { Ref } from 'react';
 
 import {
   DropdownMenu,
@@ -6,7 +7,6 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from './ui/dropdown-menu';
-import { Ref } from 'react';
 
 type DropDownItem =
   | { text: string; href: string; onClick?: never }

--- a/components/modal/AddTaskList.tsx
+++ b/components/modal/AddTaskList.tsx
@@ -1,43 +1,32 @@
 'use client';
 
 import InputField from '@/components/InputField/InputField';
-import useModalForm from '@/hooks/useModalForm';
 import Buttons from '@/components/Buttons';
 import CloseButton from '@/components/modal/ModalCloseButton';
+import { _CreateTaskListParams } from '@/app/[teamId]/(index)/TeamPage.type';
+import useForm from '@/hooks/useForm';
+import { FormEvent } from 'react';
+
+const INIT_VALUES: _CreateTaskListParams = { name: '' };
+
+interface AddTaskListProps {
+  onCreate: (params: _CreateTaskListParams) => void;
+}
 
 /**
  * 할 일 목록 추가 모달 컴포넌트.
  * 만들기 버튼 클릭 시 할 일 목록을 추가하는 기능을 제공합니다.
  *
- * @param {Function} onClick - 모달 실행 함수 (할 일 목록 추가 기능을 처리하는 함수 전달해주세요.)
+ * @param {Function} onCreate - 할 일 목록 생성 함수
  */
 
-export default function AddTaskList({
-  onClick: fetchData,
-}: {
-  onClick: (bodyData: object) => void;
-}) {
-  const { value, handleOnClick, updateInputValue } = useModalForm({
-    onClick: fetchData,
-  });
+export default function AddTaskList({ onCreate }: AddTaskListProps) {
+  const { formData, errorMessage, handleInputChange } = useForm(INIT_VALUES);
 
-  {
-    /* 꼭 읽어주세요.
-       InputField 컴포넌트에서 updateInputValue 함수를 사용할 때,
-       props로 { index, name, value }를 전달합니다.
-       name 부분은 api 요청 시 필요한 key 값으로 사용되니,
-       해당 key 값을 잘 확인하고 사용해주세요.
-
-       그리고 추가 유효성 로직이 필요하실 땐,
-       props로 받은 onClick : fetchData 와 같이 이름을 변경한 뒤에,
-       useModalForm을 불러오는 코드 이전에 onClick 이라는 이름으로 추가 유효성 로직 함수를 선언해주세요.
-
-       form에 작성한 데이터 외에 추가적으로 body 데이터를 전달해야 하는 경우,
-       이 곳에서 body 데이터를 string[] 형식으로 추가하고,
-       useModalForm에서 optional 값으로 지정된 body를 추가해서 전달해주세요.
-       작업하실 땐 이 주석을 지워주시면 감사하겠습니다.
-    */
-  }
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    onCreate(formData);
+  };
 
   return (
     <>
@@ -45,17 +34,16 @@ export default function AddTaskList({
       <div className="modal-title-wrapper">
         <h2 className="modal-title">할 일 목록</h2>
       </div>
-      <form onSubmit={handleOnClick}>
+      <form onSubmit={handleSubmit}>
         <InputField
-          value={value[0]}
+          name="name"
+          value={formData.name}
+          onChange={handleInputChange}
           placeholder="목록 명을 입력해주세요."
-          name="task-list-title"
-          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-            updateInputValue(0, 'title', e.target.value)
-          }
+          errorMessage={errorMessage.name}
         />
         <div className="modal-button-wrapper">
-          <Buttons text="만들기" onClick={() => {}} type="submit" />
+          <Buttons text="만들기" type="submit" disabled={!!errorMessage.name} />
         </div>
       </form>
     </>

--- a/components/modal/AddTaskList.tsx
+++ b/components/modal/AddTaskList.tsx
@@ -1,11 +1,12 @@
 'use client';
 
+import { FormEvent } from 'react';
+
 import InputField from '@/components/InputField/InputField';
 import Buttons from '@/components/Buttons';
 import CloseButton from '@/components/modal/ModalCloseButton';
 import { _CreateTaskListParams } from '@/app/[teamId]/(index)/TeamPage.type';
 import useForm from '@/hooks/useForm';
-import { FormEvent } from 'react';
 
 const INIT_VALUES: _CreateTaskListParams = { name: '' };
 

--- a/stories/modal.stories.tsx
+++ b/stories/modal.stories.tsx
@@ -81,7 +81,7 @@ const Template: StoryFn = () => {
     openModal(<AddTask onClick={() => handleAddTask} />);
   };
   const handleOpenAddTaskList = () => {
-    openModal(<AddTaskList onClick={() => handleAddTask} />);
+    openModal(<AddTaskList onCreate={() => handleAddTask} />);
   };
   const handleOpenAddList = () => {
     openModal(<AddList onClick={() => handleAddTask} />);


### PR DESCRIPTION
## 관련 이슈

close #232

## 변경 사항 설명

다음 기능들에 고용 모달을 적용합니다.

- 할 일 목록 생성
- 할 일 목록 수정
- 할 일 목록 삭제

추가적으로 할 일 목록의 드롭다운 컨텐츠 클릭 시 할 일 목록 상세로 이동되는 이슈가 있었는데

해당 이슈에서 위 문제를 해결했습니다.

기존 @junghwaYang 님이 구현하신 `DropDown` 컴포넌트에 `ref` props를 추가했습니다.

`ref` props는 드롭다운의 컨텐츠를 가리킵니다.

사용자가 요소를 클릭 할 때 `event.target`이 `ref.current` 내부의 요소의 경우 드롭다운을 클릭했다고 판단해

요소의 상세 페이지로 이동하지 않도록 구현했습니다.
