### PR TITLE
#228 useForm 리팩토링

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -29,7 +29,7 @@ function LoginPage() {
   } = useForm(initialValues);
 
   const route = useRouter();
-  const { reload, user } = useUser();
+  const { reload, memberships } = useUser();
   const { openModal } = useModalStore();
 
   const { showSnackbar } = useSnackbar();
@@ -61,17 +61,17 @@ function LoginPage() {
   };
 
   useEffect(() => {
-    if (user) {
+    if (memberships) {
       // STUB 로그인 후 가입된 그룹이 있을 때, 첫 번째 그룹으로 이동
-      if (user.memberships.length > 0) {
-        route.push(`/${user.memberships[0].groupId}`);
+      if (memberships.length > 0) {
+        route.push(`/${memberships[0].groupId}`);
       } else {
         route.push(`/`);
       }
     } else {
       return;
     }
-  }, [route, user]);
+  }, [route, memberships]);
 
   const requiredFields = Object.keys(initialValues);
 

--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -22,7 +22,7 @@ function SignupPage() {
   const { formData, handleInputChange, changedFields, errorMessage } =
     useForm(initialValues);
 
-  const { user } = useUser();
+  const { memberships } = useUser();
 
   const route = useRouter();
 
@@ -45,17 +45,17 @@ function SignupPage() {
   };
 
   useEffect(() => {
-    if (user) {
+    if (memberships) {
       // STUB 로그인 후 가입된 그룹이 있을 때, 첫 번째 그룹으로 이동
-      if (user.memberships.length > 0) {
-        route.push(`/${user.memberships[0].groupId}`);
+      if (memberships.length > 0) {
+        route.push(`/${memberships[0].groupId}`);
       } else {
         route.push(`/`);
       }
     } else {
       return;
     }
-  }, [route, user]);
+  }, [route, memberships]);
 
   const requiredFields = Object.keys(initialValues);
 

--- a/app/boards/addarticle/page.tsx
+++ b/app/boards/addarticle/page.tsx
@@ -26,7 +26,7 @@ export default function AddArticlePage() {
     changedFields,
     handleInputChange,
     handleFileChange,
-    handleClearImage,
+    handleClearPreview,
     resetForm,
   } = useForm(INITIAL_VALUES);
 
@@ -115,7 +115,7 @@ export default function AddArticlePage() {
             <ImageUpload
               preview={preview ?? null}
               handleFileChange={handleFileChange}
-              handleClearImage={handleClearImage}
+              handleClearPreview={handleClearPreview}
             />
           </div>
         </div>

--- a/app/boards/editarticle/[articleId]/page.tsx
+++ b/app/boards/editarticle/[articleId]/page.tsx
@@ -27,7 +27,7 @@ function EditArticlePage() {
     changedFields,
     handleInputChange,
     handleFileChange,
-    handleClearImage,
+    handleClearPreview,
     resetForm,
   } = useForm(INITIAL_VALUES);
 
@@ -143,7 +143,7 @@ function EditArticlePage() {
             <ImageUpload
               preview={preview ?? formData.image ?? null}
               handleFileChange={handleFileChange}
-              handleClearImage={handleClearImage}
+              handleClearPreview={handleClearPreview}
             />
           </div>
         </div>

--- a/app/mypage/page.tsx
+++ b/app/mypage/page.tsx
@@ -76,7 +76,8 @@ export default function MyPage() {
       onSuccess: () => {
         showSnackbar('수정이 완료 되었습니다.');
         reload();
-        setChangedFields({ image: false, nickname: false });
+        setChangedFields('image', false);
+        setChangedFields('nickname', false);
       },
       onError: () =>
         showSnackbar('수정에 실패 했습니다. 다시 시도해주세요.', 'error'),

--- a/components/ImageUpload/ImageUpload.tsx
+++ b/components/ImageUpload/ImageUpload.tsx
@@ -11,11 +11,11 @@ import ICON_PLUS from '@/public/images/icon-plus.svg';
 function ImageUpload({
   preview,
   handleFileChange,
-  handleClearImage,
+  handleClearPreview,
 }: {
   preview: string | null;
   handleFileChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
-  handleClearImage: () => void;
+  handleClearPreview: () => void;
 }) {
   const deviceType = useDeviceType();
   const mobile = deviceType === 'mobile';
@@ -43,7 +43,7 @@ function ImageUpload({
           <button
             type="button"
             className={`group absolute inset-0 flex items-center justify-center bg-black/40`}
-            onClick={handleClearImage}
+            onClick={handleClearPreview}
           >
             <Image
               src="/images/icon-cancel.svg"

--- a/components/InputField/InputField.tsx
+++ b/components/InputField/InputField.tsx
@@ -81,7 +81,7 @@ export default function InputField({
           type={
             type === 'password' ? (showPassword ? 'text' : 'password') : type
           }
-          value={value}
+          value={value ?? ''}
           placeholder={placeholder}
           disabled={disabled}
           onChange={onChange}

--- a/hooks/useFileHandler.ts
+++ b/hooks/useFileHandler.ts
@@ -1,38 +1,98 @@
 import { useCallback, useEffect, useState } from 'react';
 
-interface UseFileHandlerProps {
+import type { TAction, TFormValue } from '@/types/useForm.type';
+
+export interface UseFileHandlerProps<T extends Record<string, TFormValue>> {
+  dispatch?: React.Dispatch<TAction<T>>;
+  fileFieldKey?: keyof T;
   onFileChange?: (file: File) => void;
+  onFileClear?: () => void;
+  onErrorChange?: (error: string) => void;
 }
 
-export function useFileHandler({ onFileChange }: UseFileHandlerProps) {
-  const [preview, setPreview] = useState<string>(); // 미리보기 URL
-  const [error, setError] = useState<string>(); // 에러 메시지
+export function useFileHandler<T extends Record<string, TFormValue>>({
+  dispatch,
+  fileFieldKey,
+  onFileChange,
+  onFileClear,
+  onErrorChange,
+}: UseFileHandlerProps<T>) {
+  const [preview, setPreview] = useState<string>('');
+  const [error, setError] = useState<string>('');
 
   // 파일 변경 핸들러
   const handleFileChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
       const files = e.target.files;
-
       if (files && files[0]) {
         const file = files[0];
         const MAX_SIZE_BYTES = 10 * 1024 * 1024;
 
         // 파일 크기 검증
         if (file.size > MAX_SIZE_BYTES) {
-          setError('파일 크기는 10MB 이하여야 합니다.');
-          setPreview(undefined);
+          const errorMsg = '파일 크기는 10MB 이하여야 합니다.';
+          setError(errorMsg);
+          setPreview('');
+          if (onErrorChange) onErrorChange(errorMsg);
           return;
         }
 
         // 미리보기 URL 생성
-        setPreview(URL.createObjectURL(file));
-        setError(''); // 에러 초기화
+        const newPreview = URL.createObjectURL(file);
+        setPreview(newPreview);
+        setError('');
+        if (onErrorChange) onErrorChange('');
 
-        // 유효한 파일을 부모로 전달
+        // dispatch를 통한 파일 상태 업데이트 (필드 업데이트, 변경 상태 설정)
+        if (dispatch && fileFieldKey) {
+          dispatch({
+            type: 'UPDATE_FORM_FIELD',
+            key: fileFieldKey,
+            value: file,
+          });
+          dispatch({
+            type: 'SET_CHANGED_FIELD',
+            key: fileFieldKey,
+            changed: true,
+          });
+        }
+
+        // 추가 onFileChange 콜백 실행 (옵션)
         if (onFileChange) onFileChange(file);
       }
     },
-    [onFileChange],
+    [dispatch, fileFieldKey, onErrorChange, onFileChange],
+  );
+
+  /**
+   * 미리보기 초기화 핸들러
+   * @param isReset - true이면 리셋 상황으로 간주하여 changed 값을 false로 설정
+   */
+  const handleClearPreview = useCallback(
+    (isReset?: boolean) => {
+      if (preview) {
+        URL.revokeObjectURL(preview);
+      }
+      setPreview('');
+
+      // dispatch를 통한 파일 초기화 (필드 업데이트, 변경 상태 설정)
+      if (dispatch && fileFieldKey) {
+        dispatch({
+          type: 'UPDATE_FORM_FIELD',
+          key: fileFieldKey,
+          value: '',
+        });
+        dispatch({
+          type: 'SET_CHANGED_FIELD',
+          key: fileFieldKey,
+          changed: isReset ? false : true,
+        });
+      }
+
+      // 추가 onFileClear 콜백 실행 (옵션)
+      if (onFileClear) onFileClear();
+    },
+    [dispatch, fileFieldKey, onFileClear, preview],
   );
 
   // 미리보기 URL 메모리 해제
@@ -43,14 +103,6 @@ export function useFileHandler({ onFileChange }: UseFileHandlerProps) {
       }
     };
   }, [preview]);
-
-  // preview 이미지 삭제
-  const handleClearPreview = () => {
-    if (preview) {
-      URL.revokeObjectURL(preview);
-    }
-    setPreview('');
-  };
 
   return { preview, error, handleFileChange, handleClearPreview };
 }

--- a/hooks/useInputFieldHandler.ts
+++ b/hooks/useInputFieldHandler.ts
@@ -1,0 +1,97 @@
+import { useCallback } from 'react';
+
+import { validateField } from '@/utils/validation';
+import type { TAction, TFormValue } from '@/types/useForm.type';
+
+export interface IInputFieldHandlerProps<T extends Record<string, TFormValue>> {
+  /** 초기값 객체 */
+  initialValues: T;
+  /** useReducer의 dispatch 함수 */
+  dispatch: React.Dispatch<TAction<T>>;
+  /** 최신 formData를 참조하는 ref */
+  formDataRef: React.MutableRefObject<T>;
+  /**
+   * 디바운스된 검증 함수
+   * (key, value, updatedFormData) => void
+   */
+  debouncedValidateField: (
+    key: keyof T,
+    value: string,
+    updatedFormData: T,
+  ) => void;
+}
+
+/**
+ * 입력값의 변경 및 포커스 아웃 이벤트 핸들러를 반환하는 커스텀 훅
+ *
+ * @param {IInputFieldHandlerProps<T>} params - 입력 필드 관련 핸들러에 필요한 값들
+ * @returns { handleInputBlur, handleInputChange } - 포커스 아웃 및 변경 핸들러
+ */
+export const useInputFieldHandler = <T extends Record<string, TFormValue>>({
+  initialValues,
+  dispatch,
+  formDataRef,
+  debouncedValidateField,
+}: IInputFieldHandlerProps<T>) => {
+  /**
+   * 입력값 포커싱 아웃 핸들러
+   */
+  const handleInputBlur = (
+    e: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement>,
+  ) => {
+    const { name, value } = e.target;
+    const key = name as keyof T;
+
+    if (value === initialValues[key]) {
+      dispatch({
+        type: 'SET_ERROR_MESSAGE',
+        key,
+        error: '',
+      });
+      dispatch({
+        type: 'SET_CHANGED_FIELD',
+        key,
+        changed: false,
+      });
+      return;
+    }
+
+    const updatedFormData = { ...formDataRef.current, [key]: value };
+    const fieldErrors = validateField(
+      key,
+      value,
+      updatedFormData,
+      initialValues,
+    );
+    dispatch({
+      type: 'SET_ERROR_MESSAGE',
+      key,
+      error: fieldErrors[key] || '',
+    });
+    dispatch({
+      type: 'SET_CHANGED_FIELD',
+      key,
+      changed: value !== initialValues[key],
+    });
+  };
+
+  /**
+   * 입력값 변경 핸들러
+   */
+  const handleInputChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+      const { name, value } = e.target;
+      const key = name as keyof T;
+
+      // 현재 값과 동일하면 업데이트하지 않음
+      if (value === formDataRef.current[key]) return;
+
+      const updatedFormData = { ...formDataRef.current, [key]: value };
+      dispatch({ type: 'UPDATE_FORM_FIELD', key, value });
+      debouncedValidateField(key, value, updatedFormData);
+    },
+    [debouncedValidateField, dispatch, formDataRef, initialValues],
+  );
+
+  return { handleInputBlur, handleInputChange };
+};

--- a/reducer/formReducer.ts
+++ b/reducer/formReducer.ts
@@ -1,0 +1,57 @@
+import { initializeValues } from '@/hooks/useForm';
+import { IFormState, TAction, TFormValue } from '@/types/useForm.type';
+
+/**
+ * 폼 리듀서
+ * @param state
+ * @param action
+ * @param initialValues
+ */
+const formReducer = <T>(
+  state: IFormState<T>,
+  action: TAction<T>,
+  initialValues: T,
+): IFormState<T> => {
+  switch (action.type) {
+    // 폼 데이터 업데이트
+    case 'UPDATE_FORM_FIELD':
+      return {
+        ...state,
+        formData: { ...state.formData, [action.key]: action.value ?? '' },
+      };
+    // 에러 메시지 설정
+    case 'SET_ERROR_MESSAGE':
+      return {
+        ...state,
+        errorMessage: { ...state.errorMessage, [action.key]: action.error },
+      };
+    // 변경된 필드 설정
+    case 'SET_CHANGED_FIELD':
+      return {
+        ...state,
+        changedFields: { ...state.changedFields, [action.key]: action.changed },
+      };
+    // 폼 초기화
+    case 'RESET_FORM': {
+      const newFormData = action.newValues
+        ? { ...initialValues, ...action.newValues }
+        : initialValues;
+
+      return {
+        formData: newFormData,
+        errorMessage: initializeValues(
+          state.formData as Record<keyof T, TFormValue>,
+          '',
+        ),
+        changedFields: initializeValues(
+          state.formData as Record<keyof T, TFormValue>,
+          false,
+        ),
+      };
+    }
+    default:
+      return state;
+  }
+};
+
+export default formReducer;

--- a/stories/imageUpload.stories.tsx
+++ b/stories/imageUpload.stories.tsx
@@ -1,4 +1,4 @@
-import { Meta, StoryFn } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 
 import ImageUpload from '@/components/ImageUpload/ImageUpload';
 import useForm from '@/hooks/useForm';
@@ -19,14 +19,14 @@ export default {
 } as Meta;
 
 const Template: StoryFn<typeof ImageUpload> = (args) => {
-  const { preview, handleFileChange, handleClearImage } = useForm({});
+  const { preview, handleFileChange, handleClearPreview } = useForm({});
 
   return (
     <ImageUpload
       {...args}
       preview={preview ?? null}
       handleFileChange={handleFileChange}
-      handleClearImage={handleClearImage}
+      handleClearPreview={handleClearPreview}
     />
   );
 };

--- a/types/useForm.type.ts
+++ b/types/useForm.type.ts
@@ -1,0 +1,15 @@
+type TFormValue = string | number | File | '';
+
+interface IFormState<T> {
+  formData: T;
+  errorMessage: Partial<Record<keyof T, string>>;
+  changedFields: Partial<Record<keyof T, boolean>>;
+}
+
+type TAction<T> =
+  | { type: 'UPDATE_FORM_FIELD'; key: keyof T; value: TFormValue }
+  | { type: 'SET_ERROR_MESSAGE'; key: keyof T; error: string }
+  | { type: 'SET_CHANGED_FIELD'; key: keyof T; changed: boolean }
+  | { type: 'RESET_FORM'; newValues?: Partial<T> };
+
+export type { TFormValue, IFormState, TAction };

--- a/types/user.type.ts
+++ b/types/user.type.ts
@@ -1,6 +1,5 @@
-import { FormValue } from '@/hooks/useForm';
-
 import { IGroup, IMember } from './group.type';
+import { TFormValue } from './useForm.type';
 
 interface IMembership extends IMember {
   group: IGroup;
@@ -20,7 +19,7 @@ interface IUser extends IUserProfile {
 }
 
 interface IUserDetail extends IUser {
-  memberships: IMembership[];
+  memberships: IMembership[] | null;
 }
 
 interface UpdateUserParams {
@@ -31,7 +30,7 @@ interface UpdateUserParams {
 interface ResetPasswordEmailParams {
   email: string;
   redirectUrl: string;
-  [key: string]: FormValue;
+  [key: string]: TFormValue;
 }
 interface ResetPasswordParams extends UpdatePasswordParams {
   token: string;

--- a/utils/updatePayload.ts
+++ b/utils/updatePayload.ts
@@ -1,5 +1,5 @@
-import { FormValue } from '@/hooks/useForm';
 import { uploadImage } from '@/service/image.api';
+import { TFormValue } from '@/types/useForm.type';
 
 export type UpdatePayloadParams = {
   [key: string]: string | number | boolean | undefined | File;
@@ -8,7 +8,7 @@ export type UpdatePayloadParams = {
 
 interface updatePayloadSubmitProps<T> {
   changedFields: Record<string, boolean>;
-  formData: Record<string, FormValue>;
+  formData: Record<string, TFormValue>;
   mutate: (payload: T) => void;
   articleId?: number;
 }


### PR DESCRIPTION
## 관련 이슈

<!-- 연관된 이슈 번호를 작성해주세요 예 #15 -->

close #228 

## 요약

<!-- 작업 내용에 대해 간단히 설명해주세요 -->
- useForm내부에서 인풋필드, 이미지필드 훅으로 분리하여 호출
- useForm 내부에서 관리되는 상태들을 useState가 아닌 useReducer로 관리

## 변경 사항 설명

<!-- 구현한 내용에 대해 자세한 내용을 작성해 주세요 -->
- 명확한 네이밍을 위해 handleClearImage가 아닌 handleClearPreview로 변경되었습니다.
- useForm은 기존에 사용하시던것처럼 동일하게 사용해주시면 됩니다.
- useForm 내부에서 인풋필드 훅을 별도로 분리하고 이미지필드훅 외부에 추가되었던 이미지삭제기능을 이미지필드훅에 추가병합 하였습니다.
<!-- 추가적으로 리뷰를 원하는 부분을 알려주세요 -->

## 주의 사항
- 제가 확인했을때는 별 문제 없었지만 워낙 파일수정이 많이 되었어서 테스트 중 오류 발생 시 말씀해주세요
