### PR TITLE
#289 할 일 리스트 페이지 커스텀 훅 적용

### DIFF
--- a/app/[teamId]/tasklist/page.tsx
+++ b/app/[teamId]/tasklist/page.tsx
@@ -37,9 +37,9 @@ export default function TaskListPage() {
   const { showSnackbar } = useSnackbar();
   const { openModal } = useModalStore();
 
-  const [detailTaskId, setDetailTaskId] = useState<number | null>(null);
   const [date, setDate] = useState<Date>(new Date());
   const [isCalendarOpen, setIsCalendarOpen] = useState<boolean>(false);
+  const [detailTaskId, setDetailTaskId] = useState<number | null>(null);
 
   const { groupId } = useGroup();
   const { taskLists, refetchById } = useTaskLists({
@@ -124,13 +124,6 @@ export default function TaskListPage() {
       fetchDeleteTask.mutate(taskId);
     }
   };
-
-  // const fetchCreateTask = useMutation({
-  //   mutationFn: (body: TaskRecurringCreateDto) =>
-  //     createTask({ groupId, taskListId, body }),
-  //   onSuccess: () => fetchGetTaskList.refetch(),
-  //   onError: () => console.error('할 일 추가 실패'),
-  // });
 
   const handlePrevDate = () => {
     if (!date) return;

--- a/hooks/useTaskLists.ts
+++ b/hooks/useTaskLists.ts
@@ -1,6 +1,11 @@
 import { getTaskList } from '@/service/taskList.api';
 import useGroupStore from '@/stores/useGroup.store';
 import { useQueries, useQueryClient } from '@tanstack/react-query';
+import { useEffect } from 'react';
+
+interface UseTaskListsParams {
+  date?: string;
+}
 
 /**
  * 특정 팀에 속한 모든 할 일 목록을 관리하기 위한 커스텀 훅입니다.
@@ -12,7 +17,7 @@ import { useQueries, useQueryClient } from '@tanstack/react-query';
  * @property removeById 특정 할 일 목록 캐싱 삭제
  * @property refetchAll 모든 할 일 목록 리페칭
  */
-export default function useTaskLists() {
+export default function useTaskLists({ date }: UseTaskListsParams = {}) {
   const queryClient = useQueryClient();
   const { taskLists, setTaskLists, clearStore } = useGroupStore();
 
@@ -21,7 +26,7 @@ export default function useTaskLists() {
       taskLists?.map(({ id, groupId }) => ({
         queryKey: ['taskList', id],
         queryFn: () =>
-          getTaskList({ groupId, id, date: new Date().toISOString() }),
+          getTaskList({ groupId, id, date: date || new Date().toISOString() }),
         initialData: null,
       })) || [],
   });
@@ -52,6 +57,10 @@ export default function useTaskLists() {
     clearStore();
     queryClient.removeQueries({ queryKey: ['taskLists'] });
   };
+
+  useEffect(() => {
+    queryClient.invalidateQueries({ queryKey: ['taskList'] });
+  }, [date]);
 
   return {
     taskLists: data.length > 0 ? data : null,

--- a/stories/modal.stories.tsx
+++ b/stories/modal.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import type { Meta, StoryFn } from '@storybook/react';
 
 import useModalStore from '@/stores/modalStore';
-import AddTask from '@/components/modal/AddTask';
+// import AddTask from '@/components/modal/AddTask';
 import Modal from '@/components/modal/Modal';
 import Buttons from '@/components/Buttons';
 import Container from '@/components/layout/Container';
@@ -66,9 +66,9 @@ const Template: StoryFn = () => {
   const handleOpenAddTeam = () => {
     openModal(<AddTeam onClick={() => handleAddTask} />);
   };
-  const handleOpenAddTask = () => {
-    openModal(<AddTask onClick={() => handleAddTask} />);
-  };
+  // const handleOpenAddTask = () => {
+  //   openModal(<AddTask onClick={() => handleAddTask} />);
+  // };
   const handleOpenAddTaskList = () => {
     openModal(<AddTaskList onCreate={() => handleAddTask} />);
   };
@@ -102,7 +102,7 @@ const Template: StoryFn = () => {
           text="패스워드 변경 모달 열기"
         />
         <Buttons onClick={handleOpenAddTeam} text="팀 추가 모달 열기" />
-        <Buttons onClick={handleOpenAddTask} text="할 일 만들기 모달 열기" />
+        {/* <Buttons onClick={handleOpenAddTask} text="할 일 만들기 모달 열기" /> */}
         <Buttons onClick={handleOpenAddTaskList} text="할 일 목록 모달 열기" />
         <Buttons
           onClick={handleOpenAddList}


### PR DESCRIPTION
### **🔗 관련 이슈**

Closes #289 

---

### **📌 변경 사항**

- ✅ group id를 받아오던 로직을 useGroup의 groupId 프로퍼티로 대체
- ✅ 할 일 목록을 받아오던 로직을 useTaskList로 대체
- ✅ 할 일 목록 탭 이동 경로 수정
