### PR TITLE
#305 2차QA 14번 이슈 수정 - 비밀번호,비밀번호확인 정상 입력후 다시 비밀번호를 변경할때 버튼활성화 되는 이슈

### DIFF
--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -2,7 +2,7 @@
 
 import { useRouter } from 'next/navigation';
 import { useMutation } from '@tanstack/react-query';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 import { signUp } from '@/service/auth.api';
 import useForm from '@/hooks/useForm';
@@ -21,6 +21,9 @@ const initialValues = {
 function SignupPage() {
   const { formData, handleInputChange, changedFields, errorMessage } =
     useForm(initialValues);
+
+  const [passwordConfirmationError, setPasswordConfirmationError] =
+    useState('');
 
   const { memberships } = useUser();
 
@@ -44,6 +47,33 @@ function SignupPage() {
     postSignup(formData);
   };
 
+  const handlePasswordChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    handleInputChange(e);
+
+    // 비밀번호가 변경될 때 비밀번호 확인 필드의 오류 메시지를 업데이트
+    if (
+      formData.passwordConfirmation &&
+      e.target.value !== formData.passwordConfirmation
+    ) {
+      setPasswordConfirmationError('비밀번호가 일치하지 않습니다.');
+    } else {
+      setPasswordConfirmationError('');
+    }
+  };
+
+  const handlePasswordConfirmationChange = (
+    e: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    handleInputChange(e);
+
+    // 비밀번호 확인 필드가 변경될 때 오류 메시지를 업데이트
+    if (e.target.value !== formData.password) {
+      setPasswordConfirmationError('비밀번호가 일치하지 않습니다.');
+    } else {
+      setPasswordConfirmationError('');
+    }
+  };
+
   useEffect(() => {
     if (memberships) {
       // STUB 로그인 후 가입된 그룹이 있을 때, 첫 번째 그룹으로 이동
@@ -65,7 +95,8 @@ function SignupPage() {
     ) ||
     requiredFields.some(
       (field) => errorMessage[field as keyof typeof errorMessage] !== '',
-    );
+    ) ||
+    formData.password !== formData.passwordConfirmation;
 
   return (
     <form onSubmit={handleSubmit}>
@@ -99,7 +130,7 @@ function SignupPage() {
           name="password"
           autoComplete="new-password"
           value={formData.password}
-          onChange={handleInputChange}
+          onChange={handlePasswordChange}
           errorMessage={errorMessage.password}
           placeholder="비밀번호를 입력해주세요."
           required
@@ -111,8 +142,10 @@ function SignupPage() {
           name="passwordConfirmation"
           autoComplete="new-password"
           value={formData.passwordConfirmation}
-          onChange={handleInputChange}
-          errorMessage={errorMessage.passwordConfirmation}
+          onChange={handlePasswordConfirmationChange}
+          errorMessage={
+            errorMessage.passwordConfirmation || passwordConfirmationError
+          }
           placeholder="비밀번호를 다시 한 번 입력해주세요."
           required
         />

--- a/hooks/useForm.ts
+++ b/hooks/useForm.ts
@@ -85,12 +85,7 @@ const useForm = <T extends Record<string, TFormValue>>(initialValues: T) => {
    */
   const debouncedValidateField = useDebounce(
     (key: keyof T, value: string, updatedFormData: T) => {
-      const fieldErrors = validateField(
-        key,
-        value,
-        updatedFormData,
-        initialValues,
-      );
+      const fieldErrors = validateField(key, value, updatedFormData);
       dispatch({
         type: 'SET_ERROR_MESSAGE',
         key,

--- a/hooks/useInputFieldHandler.ts
+++ b/hooks/useInputFieldHandler.ts
@@ -57,12 +57,7 @@ export const useInputFieldHandler = <T extends Record<string, TFormValue>>({
     }
 
     const updatedFormData = { ...formDataRef.current, [key]: value };
-    const fieldErrors = validateField(
-      key,
-      value,
-      updatedFormData,
-      initialValues,
-    );
+    const fieldErrors = validateField(key, value, updatedFormData);
     dispatch({
       type: 'SET_ERROR_MESSAGE',
       key,

--- a/utils/validation.ts
+++ b/utils/validation.ts
@@ -1,13 +1,14 @@
+import { TFormValue } from '@/types/useForm.type';
+
 export const rPASSWORD =
   /^(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[!@#$%^&*])[A-Za-z\d!@#$%^&*]{8,}$/;
 
-export type FormDataType = Record<string, any>;
+export type FormDataType = Record<string, TFormValue>;
 
 export const validateField = <T extends FormDataType>(
   name: keyof T,
   value: string,
   formData: T,
-  initialValues: T,
 ): Partial<Record<keyof T, string>> => {
   const errors: Partial<Record<keyof T, string>> = {};
 
@@ -35,7 +36,7 @@ export const validateField = <T extends FormDataType>(
     case 'passwordConfirmation':
       if (value.length === 0) {
         errors[name] = '비밀번호 확인을 입력해주세요.';
-      } else if (value !== formData.password) {
+      } else if (formData.password && formData.password !== value) {
         errors[name] = '비밀번호가 일치하지 않습니다.';
       } else {
         errors[name] = '';


### PR DESCRIPTION


### **🔗 관련 이슈**

Closes #305  

---

### **📌 변경 사항**

- ✅ **[validation]** 조건 수정
- ✅ **[회원가입, 패스워드 변경]** 별도의 onChange 이벤트 및 에러메세지 추가

---

### **🛠 테스트 내역**

- [x] **UI 정상 동작 확인**
- [x] **API 요청 정상 처리 확인**

---

### **💬 리뷰 요청 사항**

- useForm내부에서 해당 비밀번호, 비밀번호 확인에 대해서 같이 작성을 하려했으나, 디바운싱 적용이 안되고, 비밀번호를 입력할때마다 검증을 하길래 별도 페이지로 뺐습니다.
- 우선 기능 구현 완료를 위해서 페이지 별로 별도 작성을 해두었는데 시간이 될때 리팩토링으로 useForm내부에서 검증진행하도록 하겠습니다
- 현재 reset-password 페이지가 진입하는 즉시 메인으로 리다이렉트 되는데 useUser 내부에서 강제 리다이렉트 시키는 것 때문에 해당 페이지 접속이 안되는것같습니다 @Woolegend 님 2차QA때 남겨두었던 사항이라 우선 비밀번호,비밀번호 확인 필드가 들어가있는 페이지에는 전부 동일한 조건 추가 했습니다.
- 그래서 회원가입과 비밀번호 변경 모달에서 변경된 검증 테스트 가능합니다.
