### PR TITLE
#303 할 일 상세 컴포넌트 개선

### DIFF
--- a/app/[teamId]/tasklist/TaskListWrapper.tsx
+++ b/app/[teamId]/tasklist/TaskListWrapper.tsx
@@ -1,4 +1,5 @@
 import KebabDropDown from '@/components/KebabDropDown';
+import Profile from '@/components/Profile/Profile';
 import TaskCard from '@/components/TaskCard/TaskCard';
 import {
   CustomDrawerContent,
@@ -12,8 +13,19 @@ import {
 } from '@/components/ui/drawer';
 import { ITask } from '@/types/task.type';
 import { ITaskList } from '@/types/taskList.type';
+import { format } from 'date-fns';
+import dayjs from 'dayjs';
 import Image from 'next/image';
 import { useState } from 'react';
+
+import IconLabel from '@/components/IconLabel';
+
+const REPEAT = {
+  ONCE: '반복 없음',
+  DAILY: '매일 반복',
+  WEEKLY: '매주 반복',
+  MONTHLY: '매월 반복',
+};
 
 interface TaskListWrapper {
   taskList: ITaskList | null;
@@ -34,25 +46,55 @@ export default function TaskListWrapper({ taskList }: TaskListWrapper) {
             </div>
           </DrawerTrigger>
         ))}
-        <CustomDrawerContent className="inset-y-0 right-0 w-pr-780 p-pr-40">
-          <DrawerClose asChild style={{ position: 'static' }}>
-            <button className="absolute right-pr-25 top-pr-16 text-gray-500">
-              <Image
-                width={20}
-                height={20}
-                src="/images/icon-close.svg"
-                alt="닫기 버튼"
-              />
-            </button>
-          </DrawerClose>
-          <DrawerHeader className="flex items-center justify-between">
-            <DrawerTitle>{task?.name}</DrawerTitle>
-            <KebabDropDown onEdit={() => {}} onDelete={() => {}} />
-          </DrawerHeader>
-          <DrawerDescription>{task?.description}</DrawerDescription>
-          <DrawerFooter></DrawerFooter>
-        </CustomDrawerContent>
+        {task && <TaskDetail task={task} />}
       </Drawer>
     </div>
+  );
+}
+
+function TaskDetail({ task }: { task: ITask }) {
+  dayjs.locale('ko');
+
+  const updatedAt = format(new Date(task.updatedAt), 'yyyy.MM.dd');
+  const date = format(new Date(task.date), 'yyyy년 M월 dd일');
+  const time = format(new Date(task.date), '오후 h:mm');
+
+  return (
+    <CustomDrawerContent className="inset-y-0 right-0 w-pr-780 gap-pr-16 p-pr-40">
+      <DrawerClose asChild style={{ position: 'static' }}>
+        <button className="absolute right-pr-25 top-pr-16 text-gray-500">
+          <Image
+            width={20}
+            height={20}
+            src="/images/icon-close.svg"
+            alt="닫기 버튼"
+          />
+        </button>
+      </DrawerClose>
+      <DrawerHeader className="w-full gap-pr-16 p-0">
+        <div className="flex items-center justify-between">
+          <DrawerTitle>{task.name}</DrawerTitle>
+          <KebabDropDown onEdit={() => {}} onDelete={() => {}} />
+        </div>
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-pr-12">
+            <Profile
+              variant="member"
+              image={task.writer?.image}
+              profileSize={32}
+            />
+            <span className="text-14m">{task.writer?.nickname}</span>
+          </div>
+          <span className="text-14">{updatedAt}</span>
+        </div>
+        <div className="flex items-center text-14">
+          <IconLabel text={date} type="calendar" hasBar />
+          <IconLabel text={time} type="time" hasBar />
+          <IconLabel text={REPEAT[task.frequency]} type="repeat" />
+        </div>
+      </DrawerHeader>
+      <DrawerDescription>{task.description}</DrawerDescription>
+      <DrawerFooter></DrawerFooter>
+    </CustomDrawerContent>
   );
 }

--- a/app/[teamId]/tasklist/TaskListWrapper.tsx
+++ b/app/[teamId]/tasklist/TaskListWrapper.tsx
@@ -14,13 +14,15 @@ import {
 import { ITask } from '@/types/task.type';
 import { ITaskList } from '@/types/taskList.type';
 import { format } from 'date-fns';
-import dayjs from 'dayjs';
 import Image from 'next/image';
 import { useRef, useState } from 'react';
 
 import IconLabel from '@/components/IconLabel';
 import IconEnter from '@/public/images/icon-enter.svg';
 import classNames from 'classnames';
+import { useQuery } from '@tanstack/react-query';
+import { getTaskComment } from '@/service/comment.api';
+import Comment from '@/components/Comment/Comment';
 
 const REPEAT = {
   ONCE: '반복 없음',
@@ -59,7 +61,11 @@ function TaskDetail({ task }: { task: ITask }) {
   const valid = true;
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
-  dayjs.locale('ko');
+  const { data: comments } = useQuery({
+    queryKey: ['comments', task.id],
+    queryFn: () => getTaskComment({ taskId: task.id }),
+    enabled: !!task,
+  });
 
   const updatedAt = format(new Date(task.updatedAt), 'yyyy.MM.dd');
   const date = format(new Date(task.date), 'yyyy년 M월 dd일');
@@ -116,24 +122,37 @@ function TaskDetail({ task }: { task: ITask }) {
       </div>
 
       {/* SECTION - Comment */}
-      <div className="flex items-center border border-x-0 border-input py-pr-12">
-        <textarea
-          className="grow resize-none bg-transparent text-14 outline-none placeholder:text-t-default"
-          ref={textareaRef}
-          name="comment"
-          rows={1}
-          onChange={handleInput}
-          placeholder="댓글을 달아주세요"
-        />
-        <button
-          type="submit"
-          className={classNames([
-            'flex items-center justify-center',
-            'size-pr-24 shrink-0 rounded-full',
-            valid ? 'bg-brand-primary' : 'bg-t-default',
-          ])}
-          children={<IconEnter />}
-        />
+      <div>
+        <div className="flex items-center border border-x-0 border-input py-pr-12">
+          <textarea
+            className="grow resize-none bg-transparent text-14 outline-none placeholder:text-t-default"
+            ref={textareaRef}
+            name="comment"
+            rows={1}
+            onChange={handleInput}
+            placeholder="댓글을 달아주세요"
+          />
+          <button
+            type="submit"
+            className={classNames([
+              'flex items-center justify-center',
+              'size-pr-24 shrink-0 rounded-full',
+              valid ? 'bg-brand-primary' : 'bg-t-default',
+            ])}
+            children={<IconEnter />}
+          />
+        </div>
+        <div>
+          {comments?.map((comment) => (
+            <Comment
+              key={comment.id}
+              type="task"
+              commentData={comment}
+              handleDeleteClick={() => {}}
+              handleUpdateSubmit={() => {}}
+            />
+          ))}
+        </div>
       </div>
 
       <DrawerFooter></DrawerFooter>

--- a/app/[teamId]/tasklist/TaskListWrapper.tsx
+++ b/app/[teamId]/tasklist/TaskListWrapper.tsx
@@ -105,8 +105,6 @@ function TaskDetail({ task }: { task: ITask }) {
     createTaskCommentMutate(formData);
   };
 
-  console.log(commentValid);
-
   return (
     <CustomDrawerContent className="inset-y-0 right-0 w-pr-780 gap-pr-16 p-pr-40">
       <DrawerClose asChild style={{ position: 'static' }}>
@@ -123,7 +121,9 @@ function TaskDetail({ task }: { task: ITask }) {
       {/* SECTION - Header */}
       <DrawerHeader className="w-full gap-pr-16 p-0">
         <div className="flex items-center justify-between">
-          <DrawerTitle>{task.name}</DrawerTitle>
+          <DrawerTitle className="text-20b text-t-primary">
+            {task.name}
+          </DrawerTitle>
           <KebabDropDown onEdit={() => {}} onDelete={() => {}} />
         </div>
         <div className="flex items-center justify-between">
@@ -133,9 +133,11 @@ function TaskDetail({ task }: { task: ITask }) {
               image={task.writer?.image}
               profileSize={32}
             />
-            <span className="text-14m">{task.writer?.nickname}</span>
+            <span className="text-14m text-t-primary">
+              {task.writer?.nickname}
+            </span>
           </div>
-          <span className="text-14">{updatedAt}</span>
+          <span className="text-14 text-t-secondary">{updatedAt}</span>
         </div>
         <div className="flex items-center text-14">
           <IconLabel text={date} type="calendar" hasBar />
@@ -145,8 +147,10 @@ function TaskDetail({ task }: { task: ITask }) {
       </DrawerHeader>
 
       {/* SECTION - Description */}
-      <div className="min-h-280 text-14">
-        <DrawerDescription>{task.description}</DrawerDescription>
+      <div className="min-h-pr-200">
+        <DrawerDescription>
+          <span className="text-14 text-t-primary">{task.description}</span>
+        </DrawerDescription>
       </div>
 
       {/* SECTION - Comment */}
@@ -171,9 +175,10 @@ function TaskDetail({ task }: { task: ITask }) {
               'size-pr-24 shrink-0 rounded-full',
               commentValid ? 'bg-brand-primary' : 'bg-t-default',
             ])}
-            children={<IconEnter />}
             disabled={!commentValid}
-          />
+          >
+            <IconEnter />
+          </button>
         </form>
 
         <div>

--- a/app/[teamId]/tasklist/TaskListWrapper.tsx
+++ b/app/[teamId]/tasklist/TaskListWrapper.tsx
@@ -16,9 +16,11 @@ import { ITaskList } from '@/types/taskList.type';
 import { format } from 'date-fns';
 import dayjs from 'dayjs';
 import Image from 'next/image';
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 
 import IconLabel from '@/components/IconLabel';
+import IconEnter from '@/public/images/icon-enter.svg';
+import classNames from 'classnames';
 
 const REPEAT = {
   ONCE: '반복 없음',
@@ -41,6 +43,7 @@ export default function TaskListWrapper({ taskList }: TaskListWrapper) {
       <Drawer direction="right">
         {taskList.tasks.map((task) => (
           <DrawerTrigger asChild key={task.id} onClick={() => setTask(task)}>
+            {/* div 박스가 없으면 trigger가 동작하지 않습니다. */}
             <div>
               <TaskCard type="taskList" taskData={task} />
             </div>
@@ -53,11 +56,22 @@ export default function TaskListWrapper({ taskList }: TaskListWrapper) {
 }
 
 function TaskDetail({ task }: { task: ITask }) {
+  const valid = true;
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
   dayjs.locale('ko');
 
   const updatedAt = format(new Date(task.updatedAt), 'yyyy.MM.dd');
   const date = format(new Date(task.date), 'yyyy년 M월 dd일');
   const time = format(new Date(task.date), '오후 h:mm');
+
+  const handleInput = () => {
+    const textarea = textareaRef.current;
+    if (textarea) {
+      textarea.style.height = 'auto';
+      textarea.style.height = `${Math.min(textarea.scrollHeight, 64)}px`;
+    }
+  };
 
   return (
     <CustomDrawerContent className="inset-y-0 right-0 w-pr-780 gap-pr-16 p-pr-40">
@@ -71,6 +85,8 @@ function TaskDetail({ task }: { task: ITask }) {
           />
         </button>
       </DrawerClose>
+
+      {/* SECTION - Header */}
       <DrawerHeader className="w-full gap-pr-16 p-0">
         <div className="flex items-center justify-between">
           <DrawerTitle>{task.name}</DrawerTitle>
@@ -93,7 +109,33 @@ function TaskDetail({ task }: { task: ITask }) {
           <IconLabel text={REPEAT[task.frequency]} type="repeat" />
         </div>
       </DrawerHeader>
-      <DrawerDescription>{task.description}</DrawerDescription>
+
+      {/* SECTION - Description */}
+      <div className="min-h-280 text-14">
+        <DrawerDescription>{task.description}</DrawerDescription>
+      </div>
+
+      {/* SECTION - Comment */}
+      <div className="flex items-center border border-x-0 border-input py-pr-12">
+        <textarea
+          className="grow resize-none bg-transparent text-14 outline-none placeholder:text-t-default"
+          ref={textareaRef}
+          name="comment"
+          rows={1}
+          onChange={handleInput}
+          placeholder="댓글을 달아주세요"
+        />
+        <button
+          type="submit"
+          className={classNames([
+            'flex items-center justify-center',
+            'size-pr-24 shrink-0 rounded-full',
+            valid ? 'bg-brand-primary' : 'bg-t-default',
+          ])}
+          children={<IconEnter />}
+        />
+      </div>
+
       <DrawerFooter></DrawerFooter>
     </CustomDrawerContent>
   );

--- a/app/[teamId]/tasklist/TaskListWrapper.tsx
+++ b/app/[teamId]/tasklist/TaskListWrapper.tsx
@@ -1,0 +1,58 @@
+import KebabDropDown from '@/components/KebabDropDown';
+import TaskCard from '@/components/TaskCard/TaskCard';
+import {
+  CustomDrawerContent,
+  Drawer,
+  DrawerClose,
+  DrawerDescription,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerTrigger,
+} from '@/components/ui/drawer';
+import { ITask } from '@/types/task.type';
+import { ITaskList } from '@/types/taskList.type';
+import Image from 'next/image';
+import { useState } from 'react';
+
+interface TaskListWrapper {
+  taskList: ITaskList | null;
+}
+
+export default function TaskListWrapper({ taskList }: TaskListWrapper) {
+  const [task, setTask] = useState<ITask | null>(null);
+
+  if (!taskList) return null;
+
+  return (
+    <div className="mb-pr-80 mt-pr-16 flex flex-col gap-pr-16">
+      <Drawer direction="right">
+        {taskList.tasks.map((task) => (
+          <DrawerTrigger asChild key={task.id} onClick={() => setTask(task)}>
+            <div>
+              <TaskCard type="taskList" taskData={task} />
+            </div>
+          </DrawerTrigger>
+        ))}
+        <CustomDrawerContent className="inset-y-0 right-0 w-pr-780 p-pr-40">
+          <DrawerClose asChild style={{ position: 'static' }}>
+            <button className="absolute right-pr-25 top-pr-16 text-gray-500">
+              <Image
+                width={20}
+                height={20}
+                src="/images/icon-close.svg"
+                alt="닫기 버튼"
+              />
+            </button>
+          </DrawerClose>
+          <DrawerHeader className="flex items-center justify-between">
+            <DrawerTitle>{task?.name}</DrawerTitle>
+            <KebabDropDown onEdit={() => {}} onDelete={() => {}} />
+          </DrawerHeader>
+          <DrawerDescription>{task?.description}</DrawerDescription>
+          <DrawerFooter></DrawerFooter>
+        </CustomDrawerContent>
+      </Drawer>
+    </div>
+  );
+}

--- a/app/[teamId]/tasklist/page.tsx
+++ b/app/[teamId]/tasklist/page.tsx
@@ -1,9 +1,8 @@
 'use client';
 
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect } from 'react';
 import 'dayjs/locale/ko';
 import Link from 'next/link';
-import { useMutation } from '@tanstack/react-query';
 import classNames from 'classnames';
 import { useSearchParams } from 'next/navigation';
 
@@ -11,20 +10,9 @@ import Container from '@/components/layout/Container';
 import PrevButtonIcon from '@/public/images/icon-prev-button.svg';
 import NextButtonIcon from '@/public/images/icon-next-button.svg';
 import CalendarButtonIcon from '@/public/images/icon-calendar-button.svg';
-import TaskDetail from '@/components/TaskDetail/TaskDetail';
-import TaskCard from '@/components/TaskCard/TaskCard';
 import useGroup from '@/hooks/useGroup';
 import Buttons from '@/components/Buttons';
 import PlusIcon from '@/public/images/icon-plus.svg';
-import { updateTask, deleteTask } from '@/service/task.api';
-import { UpdateTaskBodyParams } from '@/types/task.type';
-import {
-  getTaskComment,
-  createTaskComment,
-  updateTaskComment,
-  deleteTaskComment,
-} from '@/service/comment.api';
-import { useSnackbar } from '@/contexts/SnackBar.context';
 import useModalStore from '@/stores/modalStore';
 import AddTask from '@/components/modal/AddTask';
 import useTaskLists from '@/hooks/useTaskLists';
@@ -32,107 +20,84 @@ import { ITaskList } from '@/types/taskList.type';
 import createUrlString from '@/utils/createUrlString';
 import useDate from '@/hooks/useDate';
 
+import TaskListWrapper from './TaskListWrapper';
+
 export default function TaskListPage() {
-  const { showSnackbar } = useSnackbar();
   const { openModal } = useModalStore();
 
   const [isCalendarOpen, setIsCalendarOpen] = useState<boolean>(false);
-  const [detailTaskId, setDetailTaskId] = useState<number | null>(null);
 
   const { kstDate, prev, next } = useDate();
   const { groupId } = useGroup();
-  const { taskLists, refetchById } = useTaskLists();
+  const { taskLists } = useTaskLists();
   const taskListId = Number(useSearchParams().get('id'));
   const [taskList, setTaskList] = useState<ITaskList | null>(null);
 
-  const ref = useRef<HTMLDivElement>(null);
+  // const fetchUpdateTask = useMutation({
+  //   mutationFn: ({
+  //     taskId,
+  //     body,
+  //   }: {
+  //     taskId: number;
+  //     body: UpdateTaskBodyParams;
+  //   }) => updateTask({ groupId, taskListId, taskId, body }),
+  //   onSuccess: () => {
+  //     refetchById(taskListId);
+  //     showSnackbar('할 일이 수정되었습니다.');
+  //   },
+  //   onError: () => showSnackbar('할 일 수정할 수 없습니다.', 'error'),
+  // });
 
-  const toggleDetailTask = (taskId: number) => {
-    setDetailTaskId((prev) => (prev === taskId ? null : taskId));
-    fetchGetTaskComment.mutate(taskId);
-  };
+  // const fetchDeleteTask = useMutation({
+  //   mutationFn: (taskId: number) => deleteTask({ groupId, taskListId, taskId }),
+  //   onSuccess: () => {
+  //     refetchById(taskListId);
+  //     showSnackbar('할 일이 삭제되었습니다.');
+  //   },
+  //   onError: () => showSnackbar('할 일을 삭제할 수 없습니다.', 'error'),
+  // });
 
-  const fetchUpdateTask = useMutation({
-    mutationFn: ({
-      taskId,
-      body,
-    }: {
-      taskId: number;
-      body: UpdateTaskBodyParams;
-    }) => updateTask({ groupId, taskListId, taskId, body }),
-    onSuccess: () => {
-      refetchById(taskListId);
-      showSnackbar('할 일이 수정되었습니다.');
-    },
-    onError: () => showSnackbar('할 일 수정할 수 없습니다.', 'error'),
-  });
+  // const fetchUpdateTaskComment = useMutation({
+  //   mutationFn: ({
+  //     taskId,
+  //     commentId,
+  //     content,
+  //   }: {
+  //     taskId: number;
+  //     commentId: number;
+  //     content: string;
+  //   }) => updateTaskComment({ taskId, commentId, content }),
+  //   onSuccess: (_, variables) => fetchGetTaskComment.mutate(variables.taskId),
+  //   onError: () => showSnackbar('댓글을 수정할 수 없습니다.', 'error'),
+  // });
 
-  const fetchDeleteTask = useMutation({
-    mutationFn: (taskId: number) => deleteTask({ groupId, taskListId, taskId }),
-    onSuccess: () => {
-      refetchById(taskListId);
-      showSnackbar('할 일이 삭제되었습니다.');
-    },
-    onError: () => showSnackbar('할 일을 삭제할 수 없습니다.', 'error'),
-  });
+  // const fetchDeleteTaskComment = useMutation({
+  //   mutationFn: ({
+  //     taskId,
+  //     commentId,
+  //   }: {
+  //     taskId: number;
+  //     commentId: number;
+  //   }) => deleteTaskComment({ taskId, commentId }),
+  //   onSuccess: (_, variables) => fetchGetTaskComment.mutate(variables.taskId),
+  //   onError: () => showSnackbar('댓글을 삭제할 수 없습니다.', 'error'),
+  // });
 
-  const fetchGetTaskComment = useMutation({
-    mutationFn: (taskId: number) => getTaskComment({ taskId }),
-    onError: () => showSnackbar('댓글을 불러 올 수 없습니다.', 'error'),
-  });
+  // const handleDeleteTask = (taskId: number) => {
+  //   if (confirm('할 일을 삭제하시겠습니까?')) {
+  //     fetchDeleteTask.mutate(taskId);
+  //   }
+  // };
 
-  const fetchCreateTaskComment = useMutation({
-    mutationFn: ({ taskId, content }: { taskId: number; content: string }) =>
-      createTaskComment({ taskId, content }),
-    onSuccess: (_, variables) => fetchGetTaskComment.mutate(variables.taskId),
-    onError: () => showSnackbar('댓글을 작성할 수 없습니다.', 'error'),
-  });
-
-  const fetchUpdateTaskComment = useMutation({
-    mutationFn: ({
-      taskId,
-      commentId,
-      content,
-    }: {
-      taskId: number;
-      commentId: number;
-      content: string;
-    }) => updateTaskComment({ taskId, commentId, content }),
-    onSuccess: (_, variables) => fetchGetTaskComment.mutate(variables.taskId),
-    onError: () => showSnackbar('댓글을 수정할 수 없습니다.', 'error'),
-  });
-
-  const fetchDeleteTaskComment = useMutation({
-    mutationFn: ({
-      taskId,
-      commentId,
-    }: {
-      taskId: number;
-      commentId: number;
-    }) => deleteTaskComment({ taskId, commentId }),
-    onSuccess: (_, variables) => fetchGetTaskComment.mutate(variables.taskId),
-    onError: () => showSnackbar('댓글을 삭제할 수 없습니다.', 'error'),
-  });
-
-  const handleDeleteTask = (taskId: number) => {
-    if (confirm('할 일을 삭제하시겠습니까?')) {
-      fetchDeleteTask.mutate(taskId);
-    }
-  };
-
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (ref.current && !ref.current.contains(event.target as Node)) {
-        setIsCalendarOpen(false);
-      }
-    };
-
-    document.addEventListener('mousedown', handleClickOutside);
-
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-    };
-  }, [ref]);
+  // useEffect(() => {
+  //   const handleClickOutside = (event: MouseEvent) => {
+  //     if (ref.current && !ref.current.contains(event.target as Node)) {
+  //       setIsCalendarOpen(false);
+  //     }
+  //   };
+  //   document.addEventListener('mousedown', handleClickOutside);
+  //   return () => document.removeEventListener('mousedown', handleClickOutside);
+  // }, [ref]);
 
   useEffect(() => {
     const next = taskLists?.find((e) => e.id === taskListId) || null;
@@ -146,17 +111,17 @@ export default function TaskListPage() {
           <h1 className="text-20b">할 일</h1>
           <div className="relative mt-pr-24 flex items-center gap-pr-12">
             <span className="text-16m">{kstDate}</span>
-            <div
-              className="flex items-center gap-pr-4 text-b-secondary"
-              onClick={() => setDetailTaskId(null)}
-              ref={ref}
-            >
+            <div className="flex items-center gap-pr-4 text-b-secondary">
               <PrevButtonIcon className="cursor-pointer" onClick={prev} />
               <NextButtonIcon className="cursor-pointer" onClick={next} />
               <CalendarButtonIcon
                 className="ml-pr-8 cursor-pointer"
-                onClick={() => setIsCalendarOpen(!isCalendarOpen)}
+                onClick={() => setIsCalendarOpen((prev) => !prev)}
               />
+              {/* NOTE - 테스트 코드 */}
+              {isCalendarOpen ? (
+                <span className="text-white">달력 열림</span>
+              ) : null}
             </div>
           </div>
         </div>
@@ -182,38 +147,13 @@ export default function TaskListPage() {
             </Link>
           ))}
         </ul>
-        <div className="mb-pr-80 mt-pr-16 flex flex-col gap-pr-16">
-          {taskList?.tasks.map((task) => (
-            <div key={task.id}>
-              <div onClick={() => toggleDetailTask(task.id)}>
-                <TaskCard
-                  type="taskList"
-                  taskData={task}
-                  updateTask={fetchUpdateTask.mutate}
-                />
-              </div>
-              <div>
-                <TaskDetail
-                  isOpen={detailTaskId === task.id}
-                  setIsOpen={() => toggleDetailTask(task.id)}
-                  value={task}
-                  commentData={fetchGetTaskComment.data}
-                  postComment={fetchCreateTaskComment.mutate}
-                  deleteTask={handleDeleteTask}
-                  updateTask={fetchUpdateTask.mutate}
-                  deleteComment={fetchDeleteTaskComment.mutate}
-                  updateComment={fetchUpdateTaskComment.mutate}
-                />
-              </div>
-            </div>
-          ))}
-        </div>
+        <TaskListWrapper taskList={taskList} />
         <div className="fixed bottom-pr-48 left-1/2 flex w-full max-w-screen-xl -translate-x-1/2 items-end justify-end tamo:bottom-pr-24 tamo:pr-pr-24">
           <Buttons
             text="할 일 추가"
             icon={<PlusIcon width={16} height={16} />}
             onClick={() => openModal(<AddTask />)}
-            className={classNames('w-pr-125', detailTaskId && 'hidden')}
+            className="w-pr-125"
             rounded
           />
         </div>

--- a/components/ui/drawer.tsx
+++ b/components/ui/drawer.tsx
@@ -1,0 +1,118 @@
+'use client';
+
+import * as React from 'react';
+import { Drawer as DrawerPrimitive } from 'vaul';
+
+import { cn } from '@/lib/utils';
+
+const Drawer = ({
+  shouldScaleBackground = true,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Root>) => (
+  <DrawerPrimitive.Root
+    shouldScaleBackground={shouldScaleBackground}
+    {...props}
+  />
+);
+Drawer.displayName = 'Drawer';
+
+const DrawerTrigger = DrawerPrimitive.Trigger;
+
+const DrawerPortal = DrawerPrimitive.Portal;
+
+const DrawerClose = DrawerPrimitive.Close;
+
+const DrawerOverlay = React.forwardRef<
+  React.ElementRef<typeof DrawerPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DrawerPrimitive.Overlay
+    ref={ref}
+    className={cn('fixed inset-0 z-50 bg-black/80', className)}
+    {...props}
+  />
+));
+DrawerOverlay.displayName = DrawerPrimitive.Overlay.displayName;
+
+const DrawerContent = React.forwardRef<
+  React.ElementRef<typeof DrawerPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DrawerPortal>
+    <DrawerOverlay />
+    <DrawerPrimitive.Content
+      ref={ref}
+      className={cn(
+        'fixed inset-x-0 bottom-0 z-50 mt-24 flex h-auto flex-col rounded-t-[10px] border bg-background',
+        className,
+      )}
+      {...props}
+    >
+      <div className="mx-auto mt-4 h-2 w-[100px] rounded-full bg-muted" />
+      {children}
+    </DrawerPrimitive.Content>
+  </DrawerPortal>
+));
+DrawerContent.displayName = 'DrawerContent';
+
+const DrawerHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn('grid gap-1.5 p-4 text-center sm:text-left', className)}
+    {...props}
+  />
+);
+DrawerHeader.displayName = 'DrawerHeader';
+
+const DrawerFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn('mt-auto flex flex-col gap-2 p-4', className)}
+    {...props}
+  />
+);
+DrawerFooter.displayName = 'DrawerFooter';
+
+const DrawerTitle = React.forwardRef<
+  React.ElementRef<typeof DrawerPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DrawerPrimitive.Title
+    ref={ref}
+    className={cn(
+      'text-lg font-semibold leading-none tracking-tight',
+      className,
+    )}
+    {...props}
+  />
+));
+DrawerTitle.displayName = DrawerPrimitive.Title.displayName;
+
+const DrawerDescription = React.forwardRef<
+  React.ElementRef<typeof DrawerPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DrawerPrimitive.Description
+    ref={ref}
+    className={cn('text-sm text-muted-foreground', className)}
+    {...props}
+  />
+));
+DrawerDescription.displayName = DrawerPrimitive.Description.displayName;
+
+export {
+  Drawer,
+  DrawerPortal,
+  DrawerOverlay,
+  DrawerTrigger,
+  DrawerClose,
+  DrawerContent,
+  DrawerHeader,
+  DrawerFooter,
+  DrawerTitle,
+  DrawerDescription,
+};

--- a/components/ui/drawer.tsx
+++ b/components/ui/drawer.tsx
@@ -55,6 +55,26 @@ const DrawerContent = React.forwardRef<
 ));
 DrawerContent.displayName = 'DrawerContent';
 
+const CustomDrawerContent = React.forwardRef<
+  React.ElementRef<typeof DrawerPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DrawerPortal>
+    <DrawerOverlay />
+    <DrawerPrimitive.Content
+      ref={ref}
+      className={cn(
+        'fixed z-50 flex h-auto flex-col border bg-background',
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </DrawerPrimitive.Content>
+  </DrawerPortal>
+));
+DrawerContent.displayName = 'CustomDrawerContent';
+
 const DrawerHeader = ({
   className,
   ...props
@@ -111,6 +131,7 @@ export {
   DrawerTrigger,
   DrawerClose,
   DrawerContent,
+  CustomDrawerContent,
   DrawerHeader,
   DrawerFooter,
   DrawerTitle,

--- a/components/ui/drawer.tsx
+++ b/components/ui/drawer.tsx
@@ -73,7 +73,7 @@ const CustomDrawerContent = React.forwardRef<
     </DrawerPrimitive.Content>
   </DrawerPortal>
 ));
-DrawerContent.displayName = 'CustomDrawerContent';
+CustomDrawerContent.displayName = 'CustomDrawerContent';
 
 const DrawerHeader = ({
   className,

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@radix-ui/react-avatar": "^1.1.2",
-        "@radix-ui/react-dialog": "^1.1.4",
+        "@radix-ui/react-dialog": "^1.1.6",
         "@radix-ui/react-dropdown-menu": "^2.1.4",
         "@radix-ui/react-label": "^2.1.1",
         "@radix-ui/react-select": "^2.1.4",
@@ -44,6 +44,7 @@
         "recharts": "^2.15.1",
         "tailwind-merge": "^2.6.0",
         "tailwindcss-animate": "^1.0.7",
+        "vaul": "^1.1.2",
         "zustand": "^5.0.3"
       },
       "devDependencies": {
@@ -3278,25 +3279,25 @@
       }
     },
     "node_modules/@radix-ui/react-dialog": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.4.tgz",
-      "integrity": "sha512-Ur7EV1IwQGCyaAuyDRiOLA5JIUZxELJljF+MbM/2NC0BYwfuRrbpS30BiQBJrVruscgUkieKkqXYDOoByaxIoA==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.6.tgz",
+      "integrity": "sha512-/IVhJV5AceX620DUJ4uYVMymzsipdKBzo3edo+omeskCKGm9FRHM0ebIdbPnlQVJqyuHbuBltQUOG2mOTq2IYw==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.1",
         "@radix-ui/react-compose-refs": "1.1.1",
         "@radix-ui/react-context": "1.1.1",
-        "@radix-ui/react-dismissable-layer": "1.1.3",
+        "@radix-ui/react-dismissable-layer": "1.1.5",
         "@radix-ui/react-focus-guards": "1.1.1",
-        "@radix-ui/react-focus-scope": "1.1.1",
+        "@radix-ui/react-focus-scope": "1.1.2",
         "@radix-ui/react-id": "1.1.0",
-        "@radix-ui/react-portal": "1.1.3",
+        "@radix-ui/react-portal": "1.1.4",
         "@radix-ui/react-presence": "1.1.2",
-        "@radix-ui/react-primitive": "2.0.1",
-        "@radix-ui/react-slot": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-slot": "1.1.2",
         "@radix-ui/react-use-controllable-state": "1.1.0",
-        "aria-hidden": "^1.1.1",
-        "react-remove-scroll": "^2.6.1"
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3309,6 +3310,123 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.5.tgz",
+      "integrity": "sha512-E4TywXY6UsXNRhFrECa5HAvE5/4BFcGyfTyK36gP+pAW1ed7UTK4vKwdr53gAJYwqbfCWC6ATvJa3J3R/9+Qrg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-escape-keydown": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.2.tgz",
+      "integrity": "sha512-zxwE80FCU7lcXUGWkdt6XpTTCKPitG1XKOwViTxHVKIJhZl9MvIl2dVHeZENCWD9+EdWv05wlaEkRXUykU27RA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-use-callback-ref": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-portal": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.4.tgz",
+      "integrity": "sha512-sn2O9k1rPFYVyKd5LAJfo96JlSGVFpa1fS6UuBJfrZadudiw5tAmru+n1x7aMRQ84qDM71Zh1+SzK5QwU0tJfA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-primitive": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.0.2.tgz",
+      "integrity": "sha512-Ec/0d38EIuvDF+GZjcMU/Ze6MxntVJYO/fRlCPhCaVUyPY9WTalHJw54tp9sXeJo3tlShWpy41vQRgLRGOuz+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.1.2.tgz",
+      "integrity": "sha512-YAKxaiGsSQJ38VzKH86/BPRC4rh+b1Jpa+JneA5LRE7skmLPNAyeG8kPJj/oo4STLvlrs8vkf/iYyc3A5stYCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }
@@ -15613,16 +15731,16 @@
       }
     },
     "node_modules/react-remove-scroll": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.6.2.tgz",
-      "integrity": "sha512-KmONPx5fnlXYJQqC62Q+lwIeAk64ws/cUw6omIumRzMRPqgnYqhSSti99nbj0Ry13bv7dF+BKn7NB+OqkdZGTw==",
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.6.3.tgz",
+      "integrity": "sha512-pnAi91oOk8g8ABQKGF5/M9qxmmOPxaAnopyTHYfqYEwJhyFrbbBtHuSgtKEoH0jpcxx5o3hXqH1mNd9/Oi+8iQ==",
       "license": "MIT",
       "dependencies": {
         "react-remove-scroll-bar": "^2.3.7",
-        "react-style-singleton": "^2.2.1",
+        "react-style-singleton": "^2.2.3",
         "tslib": "^2.1.0",
         "use-callback-ref": "^1.3.3",
-        "use-sidecar": "^1.1.2"
+        "use-sidecar": "^1.1.3"
       },
       "engines": {
         "node": ">=10"
@@ -19120,6 +19238,19 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/vaul": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vaul/-/vaul-1.1.2.tgz",
+      "integrity": "sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-dialog": "^1.1.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/vfile": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@radix-ui/react-avatar": "^1.1.2",
-    "@radix-ui/react-dialog": "^1.1.4",
+    "@radix-ui/react-dialog": "^1.1.6",
     "@radix-ui/react-dropdown-menu": "^2.1.4",
     "@radix-ui/react-label": "^2.1.1",
     "@radix-ui/react-select": "^2.1.4",
@@ -48,6 +48,7 @@
     "recharts": "^2.15.1",
     "tailwind-merge": "^2.6.0",
     "tailwindcss-animate": "^1.0.7",
+    "vaul": "^1.1.2",
     "zustand": "^5.0.3"
   },
   "devDependencies": {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -81,7 +81,7 @@ const shadcnConfig: Config = {
         },
         t: {
           primary: 'var(--t-primary-light)',
-          secondary: 'var(--t-secondary)',
+          secondary: 'var(--t-secondary-light)',
           tertiary: 'var(--t-tertiary)',
           default: 'var(--t-default)',
           inverse: 'var(--t-inverse)',

--- a/utils/validation.ts
+++ b/utils/validation.ts
@@ -59,6 +59,12 @@ export const validateField = <T extends FormDataType>(
         errors[name] = '';
       }
       break;
+    case 'content':
+      if (value.length === 0) {
+        errors[name] = '내용은 필수 입력입니다.';
+      } else {
+        errors[name] = '';
+      }
     default:
       break;
   }


### PR DESCRIPTION
## **✨ New Feature: 할 일 상세 컴포넌트 개선**

### **🔗 관련 이슈**

Closes #303 

---

### **📌 변경 사항**

- ✅ **할 일 상세 컴포넌트에 ShadCN drawer 컴포넌트 적용**
- ✅ **할 일 상세에서 댓글 작성 기능 구현**
- ✅ **할 일 상세 관련 API 바운더리 재설정**
- ✅ **text-t-secondary 설정**

---

### **🚀 기대 효과**

✔ **할 일 상세에 drawer 적용으로 인해 사용자 경험 향상**
✔ **할 일 목록 불러오기 시 useTaskLists 사용으로 인해 불필요 요청 감소**
✔ **API 바운더리 명확하게 변경해 코드 가독성 향상**

---

### **🛠 테스트 내역**

- [x] **UI 정상 동작 확인**
- [x] **API 요청 정상 처리 확인**
- [x] **테스트 코드 실행 완료**

---

### **💬 리뷰 요청 사항**

- 할 일 상세 레이아웃은 기조의 @JUYOUNG0728 님이 구현해 주신 것을 거의 그대로 사용했습니다.
- text-t-secondary 색상이 정의가 안 되어 있었는데 이제 발견했습니다 ㅋㅋ!
