### PR TITLE
게시글 수정페이지 Preview 미노출 이슈

### DIFF
--- a/app/boards/editarticle/[articleId]/page.tsx
+++ b/app/boards/editarticle/[articleId]/page.tsx
@@ -30,6 +30,7 @@ function EditArticlePage() {
     handleFileChange,
     handleClearPreview,
     resetForm,
+    setFormData,
   } = useForm(INITIAL_VALUES);
 
   const [prevValue, setPrevValue] = useState(INITIAL_VALUES);
@@ -50,12 +51,16 @@ function EditArticlePage() {
         const response = await getArticleDetail({
           articleId: Number(articleId),
         });
+
         const values = {
           title: response.title,
           content: response.content,
           image: response.image ?? '',
         };
-        resetForm(values);
+
+        setFormData('title', response.title);
+        setFormData('content', response.content);
+        setFormData('image', response.image || '');
         setPrevValue(values);
       }
     };
@@ -136,7 +141,7 @@ function EditArticlePage() {
 
           <div className="mt-pr-40 tamo:mt-pr-32">
             <ImageUpload
-              preview={preview ?? formData.image ?? null}
+              preview={preview || formData.image}
               handleFileChange={handleFileChange}
               handleClearPreview={handleClearPreview}
             />

--- a/components/ImageUpload/ImageUpload.tsx
+++ b/components/ImageUpload/ImageUpload.tsx
@@ -45,7 +45,7 @@ function ImageUpload({
           <button
             type="button"
             className={`group absolute inset-0 flex items-center justify-center bg-black/40`}
-            onClick={handleClearPreview}
+            onClick={() => handleClearPreview()}
           >
             <Image
               src="/images/icon-cancel.svg"

--- a/hooks/useFileHandler.ts
+++ b/hooks/useFileHandler.ts
@@ -80,7 +80,7 @@ export function useFileHandler<T extends Record<string, TFormValue>>({
         dispatch({
           type: 'UPDATE_FORM_FIELD',
           key: fileFieldKey,
-          value: '',
+          value: null,
         });
         dispatch({
           type: 'SET_CHANGED_FIELD',

--- a/reducer/formReducer.ts
+++ b/reducer/formReducer.ts
@@ -17,7 +17,7 @@ const formReducer = <T>(
     case 'UPDATE_FORM_FIELD':
       return {
         ...state,
-        formData: { ...state.formData, [action.key]: action.value ?? '' },
+        formData: { ...state.formData, [action.key]: action.value ?? null },
       };
     // 에러 메시지 설정
     case 'SET_ERROR_MESSAGE':

--- a/types/useForm.type.ts
+++ b/types/useForm.type.ts
@@ -1,4 +1,4 @@
-type TFormValue = string | number | File | Date | '' | number[];
+type TFormValue = string | number | File | Date | '' | number[] | null;
 
 interface IFormState<T> {
   formData: T;

--- a/utils/updatePayload.ts
+++ b/utils/updatePayload.ts
@@ -2,7 +2,7 @@ import { uploadImage } from '@/service/image.api';
 import { TFormValue } from '@/types/useForm.type';
 
 export type UpdatePayloadParams = {
-  [key: string]: string | number | boolean | undefined | File;
+  [key: string]: string | number | boolean | undefined | File | null;
   image?: string;
 };
 


### PR DESCRIPTION
Closes #304 

---

### **📌 변경 사항**

- ✅ 게시글 수정 페이지에서 등록된 게시글 이미지가 `Preview`로 노출되도록
- ✅ `useForm` 관련 코드 수정(이미지가 없는 경우 빈 값이 아닌 `null`로 저장되도록)

---

### **🛠 테스트 내역**

- [x] 프로필 이미지 업로드 변경 테스트
- [x] 팀 프로필 이미지 변경 테스트
- [x] 이미지가 등록된 게시글의 수정 페이지에서 `Preview`가 잘 노출되는지
- [x] 이미지 변경 및 이미지 제거가 되는지

---

### **💬 리뷰 요청 사항**

`useForm` 관련 코드에서 `image`가 업로드되지 않았을 때 빈값이 아닌 `null` 값으로 `formData`에 저장되게 수정했습니다.
빈값에서 `null` 값으로 변경한 이유는 게시글 `PATCH` 할 때 `image`가 등록되지 않았을 때 빈값이 아닌 `null` 값으로만 요청을 받아 수정하게 되었습니다.
업로드 기능이 있는 다른 페이지 테스트는 진행하여 문제없는 것을 확인했습니다. 