### PR TITLE
#315 할일 리스트 캘린더 추가

### DIFF
--- a/app/[teamId]/tasklist/page.tsx
+++ b/app/[teamId]/tasklist/page.tsx
@@ -19,15 +19,14 @@ import useTaskLists from '@/hooks/useTaskLists';
 import { ITaskList } from '@/types/taskList.type';
 import createUrlString from '@/utils/createUrlString';
 import useDate from '@/hooks/useDate';
+import DatePicker from '@/components/DateTimePicker/DatePicker';
 
 import TaskListWrapper from './TaskListWrapper';
 
 export default function TaskListPage() {
   const { openModal } = useModalStore();
 
-  const [isCalendarOpen, setIsCalendarOpen] = useState<boolean>(false);
-
-  const { kstDate, prev, next } = useDate();
+  const { kstDate, prev, next, date, set } = useDate();
   const { groupId } = useGroup();
   const { taskLists } = useTaskLists();
   const taskListId = Number(useSearchParams().get('id'));
@@ -77,19 +76,30 @@ export default function TaskListPage() {
       <Container className="relative h-screen">
         <div className="mt-pr-40 text-t-primary">
           <h1 className="text-20b">할 일</h1>
-          <div className="relative mt-pr-24 flex items-center gap-pr-12">
-            <span className="text-16m">{kstDate}</span>
-            <div className="flex items-center gap-pr-4 text-b-secondary">
-              <PrevButtonIcon className="cursor-pointer" onClick={prev} />
-              <NextButtonIcon className="cursor-pointer" onClick={next} />
-              <CalendarButtonIcon
-                className="ml-pr-8 cursor-pointer"
-                onClick={() => setIsCalendarOpen((prev) => !prev)}
-              />
-              {/* NOTE - 테스트 코드 */}
-              {isCalendarOpen ? (
-                <span className="text-white">달력 열림</span>
-              ) : null}
+          <div className="relative mt-pr-24 flex items-center">
+            <span className="w-pr-110 text-16m">{kstDate}</span>
+            <div className="flex items-center gap-pr-12 text-b-secondary">
+              <div className="flex items-center gap-pr-4">
+                <PrevButtonIcon
+                  className="size-pr-16 cursor-pointer"
+                  onClick={prev}
+                  width={16}
+                  height={16}
+                />
+                <NextButtonIcon
+                  className="size-pr-16 cursor-pointer"
+                  onClick={next}
+                  width={16}
+                  height={16}
+                />
+              </div>
+              <DatePicker
+                selectedDate={new Date(date)}
+                onDateChange={set}
+                className="top-pr-40 w-pr-336 text-t-primary mo:-left-pr-168 mo:w-pr-288"
+              >
+                <CalendarButtonIcon className="cursor-pointer" />
+              </DatePicker>
             </div>
           </div>
         </div>

--- a/components/DateTimePicker/DatePicker.tsx
+++ b/components/DateTimePicker/DatePicker.tsx
@@ -1,51 +1,44 @@
 'use client';
 
-import { useState } from 'react';
-import { format } from 'date-fns';
+import classNames from 'classnames';
 
 import { Calendar } from '@/components/ui/calendar';
-import InputField from '@/components/InputField/InputField';
+import { useToggle } from '@/hooks/useToggle';
 
 /**
  * DatePicker 컴포넌트는 달력을 표시하고 선택한 날짜를 반환합니다.
  * @param {Function} onDateChange - 날짜 변경 시 호출되는 함수
  */
 export default function DatePicker({
+  selectedDate,
   onDateChange,
+  children,
+  className,
 }: {
+  selectedDate: Date;
   onDateChange: (date: Date) => void;
+  children: React.ReactNode;
+  className?: string;
 }) {
-  const [isOpen, setIsOpen] = useState<boolean>(false);
-  const [date, setdate] = useState<Date>(new Date());
-
-  const formattedDate = date ? format(date, 'yyyy년 MM월 dd일') : '';
-
-  const handleDateSelect = (selectedDate: Date) => {
-    setdate(selectedDate);
-    onDateChange(selectedDate);
-  };
+  const [isOpen, toggleIsOpen] = useToggle();
 
   return (
-    <>
-      <div className="relative flex w-full flex-col gap-pr-8">
-        <InputField
-          value={formattedDate}
-          name="date"
-          onClick={() => setIsOpen(!isOpen)}
-          readOnly
+    <div className="relative flex w-full flex-col gap-pr-8">
+      <div onClick={toggleIsOpen}>{children}</div>
+      {isOpen && (
+        <Calendar
+          mode="single"
+          selected={selectedDate}
+          onSelect={(date: Date | undefined) => {
+            if (date) onDateChange(date);
+          }}
+          onDayClick={toggleIsOpen}
+          className={classNames(
+            'absolute left-0 top-pr-60 z-10 flex min-h-pr-258 w-full items-center justify-center rounded-2xl border border-brand-primary bg-b-secondary p-pr-16',
+            className,
+          )}
         />
-        {isOpen && (
-          <Calendar
-            mode="single"
-            selected={date}
-            onSelect={(selectedDate: Date | undefined) => {
-              if (selectedDate) handleDateSelect(selectedDate);
-            }}
-            onDayClick={() => setIsOpen(false)}
-            className="absolute left-0 top-pr-60 z-10 flex min-h-pr-258 w-full items-center justify-center rounded-2xl border border-brand-primary bg-b-secondary p-pr-16"
-          />
-        )}
-      </div>
-    </>
+      )}
+    </div>
   );
 }

--- a/components/modal/AddTask.tsx
+++ b/components/modal/AddTask.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useParams, useSearchParams } from 'next/navigation';
+import { format } from 'date-fns';
 
 import SelectBox from '@/components/SelectBox';
 import Buttons from '@/components/Buttons';
@@ -23,6 +24,9 @@ export default function AddTask() {
   const searchParams = useSearchParams();
   const teamId = Number(params.teamId);
   const taskListId = Number(searchParams.get('id'));
+
+  const [date, setdate] = useState<Date>(new Date());
+  const formattedDate = date ? format(date, 'yyyy년 MM월 dd일') : '';
 
   const kstDate = new Date();
   kstDate.setHours(kstDate.getHours() + 9);
@@ -150,11 +154,15 @@ export default function AddTask() {
         <div className="flex flex-col">
           <InputLabel label="시작 날짜 및 시간" />
           <DatePicker
+            selectedDate={date}
             onDateChange={(date: Date) => {
+              setdate(date);
               const isoDate = date.toISOString();
               setFormData('startDate', isoDate);
             }}
-          />
+          >
+            <InputField value={formattedDate} name="startDate" readOnly />
+          </DatePicker>
         </div>
         <div className="flex gap-pr-12">
           <div>

--- a/components/ui/calendar.tsx
+++ b/components/ui/calendar.tsx
@@ -76,9 +76,9 @@ function Calendar({
       components={{
         IconLeft: () =>
           isDarkMode ? (
-            <ChevronLeftIcon width={24} height={24} style={{ fill: 'black' }} />
+            <ChevronLeftIcon width={24} height={24} />
           ) : (
-            <ChevronLeftIcon width={24} height={24} style={{ fill: 'black' }} />
+            <ChevronLeftIcon width={24} height={24} />
           ),
         IconRight: () => <ChevronRightIcon width={24} height={24} />,
       }}

--- a/hooks/useDate.ts
+++ b/hooks/useDate.ts
@@ -1,12 +1,14 @@
-import useDateStore from '@/stores/useDateStore';
-import { addDays, format, subDays } from 'date-fns';
-import dayjs from 'dayjs';
+import { addDays, format, subDays, getDay } from 'date-fns';
 
+import useDateStore from '@/stores/useDateStore';
+
+const DAYS_IN_KOREAN = ['일', '월', '화', '수', '목', '금', '토'];
 const useDate = () => {
   const { date, setDate } = useDateStore();
-  dayjs.locale('ko');
 
-  const kstDate = format(date, 'M월 d일 (E)');
+  const dayIndex = getDay(date);
+  const dayInKorean = DAYS_IN_KOREAN[dayIndex];
+  const kstDate = `${format(date, 'M월 d일')} (${dayInKorean})`;
 
   /**
    * NOTE

--- a/hooks/useToggle.tsx
+++ b/hooks/useToggle.tsx
@@ -1,0 +1,9 @@
+import { useState } from 'react';
+
+export function useToggle(
+  initialValue: boolean = false,
+): [boolean, () => void] {
+  const [state, setState] = useState(initialValue);
+  const toggle = () => setState(!state);
+  return [state, toggle];
+}


### PR DESCRIPTION
## **✨ New Feature: [할일 리스트 캘린더] 추가**

### **🔗 관련 이슈**

Closes #315 

---

### **📌 변경 사항**

- ✅ **[할일 리스트 캘린더]** 구현 완료
- ✅ **[DatePicker 컴포넌트]** 재사용성을 위해 필드 분리
- ✅ **useDate** 요일 한국어 패치 완료
- ✅ **useToggle 훅** 생성

---

### **🚀 기대 효과**

✔ **사용자 경험 개선**: [기능 추가로 인해 사용성이 향상됨]  
✔ **퍼포먼스 최적화**: [단순 토글 기능에 대한 함수를 훅으로 분리하여 전역으로 사용가능(재사용성 증가)]

---

### **🛠 테스트 내역**

- [x] **UI 정상 동작 확인**
- [x] **API 요청 정상 처리 확인**
- [x] **테스트 코드 실행 완료**

---

### **💬 리뷰 요청 사항**

- 기능 구현이 적절한지 검토 요청
- UX/UI 개선이 필요한 부분 피드백 요청
