### PR TITLE
#327 할일 추가 모달에서 이전 날짜 선택 시 경고 스낵바 추가

### DIFF
--- a/components/DateTimePicker/DatePicker.tsx
+++ b/components/DateTimePicker/DatePicker.tsx
@@ -1,10 +1,10 @@
 'use client';
 
 import classNames from 'classnames';
+import { isBefore } from 'date-fns';
 
 import { Calendar } from '@/components/ui/calendar';
 import { useToggle } from '@/hooks/useToggle';
-import { useSnackbar } from '@/contexts/SnackBar.context';
 
 /**
  * DatePicker 컴포넌트는 달력을 표시하고 선택한 날짜를 반환합니다.
@@ -29,7 +29,6 @@ export default function DatePicker({
   prevDates?: boolean;
 }) {
   const [isOpen, toggleIsOpen] = useToggle();
-  const { showSnackbar } = useSnackbar();
   const today = new Date();
   today.setHours(0, 0, 0, 0);
 
@@ -41,15 +40,10 @@ export default function DatePicker({
           mode="single"
           selected={selectedDate}
           onSelect={(date: Date | undefined) => {
-            if (date) {
-              if (!prevDates && date < today) {
-                showSnackbar('오늘 이전 날짜는 선택할 수 없습니다.', 'error');
-                return;
-              }
-              onDateChange(date);
-            }
+            if (date) onDateChange(date);
           }}
           onDayClick={toggleIsOpen}
+          disabled={(date) => !prevDates && isBefore(date, today)}
           className={classNames(
             'absolute left-0 z-10 flex min-h-pr-258 w-full items-center justify-center rounded-2xl border border-brand-primary bg-b-secondary p-pr-16',
             className,

--- a/components/DateTimePicker/DatePicker.tsx
+++ b/components/DateTimePicker/DatePicker.tsx
@@ -4,23 +4,34 @@ import classNames from 'classnames';
 
 import { Calendar } from '@/components/ui/calendar';
 import { useToggle } from '@/hooks/useToggle';
+import { useSnackbar } from '@/contexts/SnackBar.context';
 
 /**
  * DatePicker 컴포넌트는 달력을 표시하고 선택한 날짜를 반환합니다.
- * @param {Function} onDateChange - 날짜 변경 시 호출되는 함수
+ *
+ * @param {Date} props.selectedDate - 선택된 날짜
+ * @param {Function} props.onDateChange - 날짜 변경 시 호출되는 함수
+ * @param {ReactNode} props.children - 캘린더 오픈 트리거
+ * @param {string} props.className - 컴포넌트 스타일 클래스
+ * @param {boolean} props.allowPastDates - 과거 날짜 선택 허용 여부
  */
 export default function DatePicker({
   selectedDate,
   onDateChange,
   children,
   className,
+  prevDates = true,
 }: {
   selectedDate: Date;
   onDateChange: (date: Date) => void;
   children: React.ReactNode;
   className?: string;
+  prevDates?: boolean;
 }) {
   const [isOpen, toggleIsOpen] = useToggle();
+  const { showSnackbar } = useSnackbar();
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
 
   return (
     <div className="relative flex w-full flex-col gap-pr-8">
@@ -30,11 +41,17 @@ export default function DatePicker({
           mode="single"
           selected={selectedDate}
           onSelect={(date: Date | undefined) => {
-            if (date) onDateChange(date);
+            if (date) {
+              if (!prevDates && date < today) {
+                showSnackbar('오늘 이전 날짜는 선택할 수 없습니다.', 'error');
+                return;
+              }
+              onDateChange(date);
+            }
           }}
           onDayClick={toggleIsOpen}
           className={classNames(
-            'absolute left-0 top-pr-60 z-10 flex min-h-pr-258 w-full items-center justify-center rounded-2xl border border-brand-primary bg-b-secondary p-pr-16',
+            'absolute left-0 z-10 flex min-h-pr-258 w-full items-center justify-center rounded-2xl border border-brand-primary bg-b-secondary p-pr-16',
             className,
           )}
         />

--- a/components/modal/AddTask.tsx
+++ b/components/modal/AddTask.tsx
@@ -160,6 +160,8 @@ export default function AddTask() {
               const isoDate = date.toISOString();
               setFormData('startDate', isoDate);
             }}
+            prevDates={false}
+            className="top-pr-60"
           >
             <InputField value={formattedDate} name="startDate" readOnly />
           </DatePicker>


### PR DESCRIPTION
### **🔗 관련 이슈**

Closes #327

---

### **📌 변경 사항**

- ✅ **[이전날짜 클릭 시 스낵바 노출]** 구현 완료
- ✅ **[할일 리스트 달력 클릭 시 ]** UI 개선

---

### **🚀 기대 효과**

✔ **사용자 경험 개선**: [할일 생성 시 이전날짜는 선택 불가]  
✔ **UI 개선**: [할일 리스트에서 달력 클릭 시 너무 멀어지지않게 개선]

---

### **🛠 테스트 내역**

- [x] **UI 정상 동작 확인**
- [x] **API 요청 정상 처리 확인**

---

### **💬 리뷰 요청 사항**

- UX/UI 개선이 필요한 부분 피드백 요청
