### PR TITLE
#329 메인 랜딩 QA 반영(bg컬러 및 라이트모드)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -119,7 +119,7 @@ export default function LandingPage() {
             src="/images/landing/img-Landing-bottom-mo.png"
             alt="background-bottom-mobile"
             fill
-            className="absolute inset-0 hidden bg-slate-950 object-cover mo:block"
+            className="absolute inset-0 hidden object-cover mo:block"
           />
 
           <div className="absolute top-pr-230 flex flex-col items-center mo:top-pr-123 ta:top-pr-176">

--- a/components/Landing/LandingCardItemsthird.tsx
+++ b/components/Landing/LandingCardItemsthird.tsx
@@ -4,7 +4,7 @@ import IconBox from './Iconbox';
 
 const LandingCardItemsthird = () => {
   return (
-    <div className="bg-b-primary-2 relative h-pr-419 w-pr-996 rounded-pr-40 mo:h-pr-467 mo:w-pr-343 ta:h-pr-354 ta:w-pr-696">
+    <div className="relative h-pr-419 w-pr-996 rounded-pr-40 bg-b-primary-2 mo:h-pr-467 mo:w-pr-343 ta:h-pr-354 ta:w-pr-696">
       <div className="relative flex size-full rounded-pr-40 mo:flex-col-reverse">
         <div className="flex h-full w-1/2 items-start justify-end mo:w-full mo:items-start mo:justify-center">
           <Image

--- a/components/Landing/LandingCardItemsthird.tsx
+++ b/components/Landing/LandingCardItemsthird.tsx
@@ -4,7 +4,7 @@ import IconBox from './Iconbox';
 
 const LandingCardItemsthird = () => {
   return (
-    <div className="relative h-pr-419 w-pr-996 rounded-pr-40 bg-slate-950 mo:h-pr-467 mo:w-pr-343 ta:h-pr-354 ta:w-pr-696">
+    <div className="bg-b-primary-2 relative h-pr-419 w-pr-996 rounded-pr-40 mo:h-pr-467 mo:w-pr-343 ta:h-pr-354 ta:w-pr-696">
       <div className="relative flex size-full rounded-pr-40 mo:flex-col-reverse">
         <div className="flex h-full w-1/2 items-start justify-end mo:w-full mo:items-start mo:justify-center">
           <Image

--- a/styles/base.css
+++ b/styles/base.css
@@ -25,6 +25,8 @@
     /* background */
     --b-primary-dark: #0f172a;
     --b-primary-light: #ffffff;
+    --b-primary-2-dark: #020617;
+    --b-primary-2-light: #fcfcfc;
     --b-secondary-dark: #1e293b;
     --b-secondary-light: #f1f5f9;
     --b-secondary-2-dark: #18212f;
@@ -65,6 +67,7 @@
   .dark {
     --background: #0f172a;
     --b-primary-light: var(--b-primary-dark);
+    --b-primary-2-light: var(--b-primary-2-dark);
     --b-secondary-light: var(--b-secondary-dark);
     --b-secondary-2-light: var(--b-secondary-2-dark);
     --b-tertiary-light: var(--b-tertiary-dark);
@@ -79,6 +82,7 @@
   }
   .light {
     --b-primary-dark: var(--b-primary-light);
+    --b-primary-2-dark: var(--b-primary-2-light);
     --b-secondary-dark: var(--b-secondary-light);
     --b-secondary-2-dark: var(--b-secondary-2-light);
     --b-tertiary-dark: var(--b-tertiary-light);

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -74,6 +74,7 @@ const shadcnConfig: Config = {
         },
         b: {
           primary: 'var(--b-primary-light)',
+          'primary-2': 'var(--b-primary-2-light)',
           secondary: 'var(--b-secondary-light)',
           'secondary-2': 'var(--b-secondary-2-light)',
           tertiary: 'var(--b-tertiary-light)',


### PR DESCRIPTION
### **🔗 관련 이슈**

Closes #329 (← 여기에 이슈 번호 입력)

---

### **📌 변경 사항**

- ✅ **[모바일 랜딩 하단 bg 컬러]** 시안에 맞게 수정
- ✅ **[랜딩 bg 컬러]** 추가
- ✅ **[랜딩 3번째 item 라이트모드]** 적용

---

### **🛠 테스트 내역**

- [x] **UI 정상 동작 확인**

---

### **💬 리뷰 요청 사항**

- UX/UI 개선이 필요한 부분 피드백 요청
- 세번째 컨텐츠의 경우 피그마 디자인시스템에 명시된게 없어서 #fff에서 살짝 어두운 계열로 잡아두긴했는데 모니터 환경에 따라 안보일수도있습니다. 이부분을 어떻게 해야할지 의견주세요
- 확인하다보니 item 2,3번째는 box-shadow가 포함되어있지않은것같아서 이거는 랜딩 리팩토링 하면서 추가하겠습니다
