### PR TITLE
💄 랜딩페이지 애니메이션 적용 및 자유게시판, 팀 리스트 케러셀 인디케이터 추가, 수정

### DIFF
--- a/app/[teamId]/(index)/GroupReportContent.tsx
+++ b/app/[teamId]/(index)/GroupReportContent.tsx
@@ -14,6 +14,7 @@ import { ITaskList } from '@/types/taskList.type';
 import IconTodo from '@/public/images/icon-report-todo.svg';
 import IconDone from '@/public/images/icon-report-done.svg';
 import parseTasks from '@/utils/parseTasks';
+import Indicators from '@/components/Indicators';
 
 import TodayProgressChart from './charts/TodayProgressChart';
 import TodayTasksChart from './charts/TodayTasksChart';
@@ -120,17 +121,6 @@ function ChartContent({ taskLists }: ChartContentProps) {
 
 function MobileChartContent({ taskLists }: ChartContentProps) {
   const [api, setApi] = useState<CarouselApi>();
-  const [current, setCurrent] = useState(0);
-
-  useEffect(() => {
-    if (!api) {
-      return;
-    }
-
-    api.on('select', () => {
-      setCurrent(api.selectedScrollSnap());
-    });
-  }, [api]);
 
   return (
     <div>
@@ -144,14 +134,8 @@ function MobileChartContent({ taskLists }: ChartContentProps) {
           </CarouselItem>
         </CarouselContent>
       </Carousel>
-      <div className="flex justify-center gap-pr-8">
-        <div
-          className={`size-pr-12 rounded-full transition-all duration-300 ${current ? 'bg-b-tertiary' : 'bg-t-primary'}`}
-        />
-        <div
-          className={`size-pr-12 rounded-full transition-all duration-300 ${current ? 'bg-t-primary' : 'bg-b-tertiary'}`}
-        />
-      </div>
+
+      <Indicators api={api} />
     </div>
   );
 }

--- a/app/boards/BestArticleList.tsx
+++ b/app/boards/BestArticleList.tsx
@@ -1,13 +1,16 @@
 import Autoplay from 'embla-carousel-autoplay';
+import { useState } from 'react';
 
 import ArticleCard from '@/components/ArticleCard/ArticleCard';
 import { useDeviceType } from '@/contexts/DeviceTypeContext';
 import useGetArticle from '@/hooks/useGetArticle';
 import {
   Carousel,
+  CarouselApi,
   CarouselContent,
   CarouselItem,
 } from '@/components/ui/carousel';
+import Indicators from '@/components/Indicators';
 
 import ArticleSkeleton from './ArticleSkeleton';
 
@@ -22,6 +25,9 @@ const PAGE_SIZE = {
  */
 function BestArticleList() {
   const deviceType = useDeviceType();
+  const isMobile = deviceType === 'mobile';
+
+  const [api, setApi] = useState<CarouselApi>();
 
   const {
     data: bestArticleList,
@@ -41,30 +47,35 @@ function BestArticleList() {
       <h3 className="text-20b">베스트 게시글</h3>
       <div className="mt-pr-32 flex gap-x-pr-19 mo:mt-pr-24 ta:gap-x-pr-16">
         {!isLoading ? (
-          <Carousel
-            opts={{
-              align: 'start',
-            }}
-            plugins={[
-              Autoplay({
-                delay: 2500,
-              }),
-            ]}
-            className="w-full"
-          >
-            <CarouselContent>
-              {bestArticleList?.list.map((bestArticle) => {
-                return (
-                  <CarouselItem
-                    key={bestArticle.id}
-                    className="md:basis-1/2 lg:basis-1/3"
-                  >
-                    <ArticleCard type="best" articleData={bestArticle} />
-                  </CarouselItem>
-                );
-              })}
-            </CarouselContent>
-          </Carousel>
+          <>
+            <Carousel
+              opts={{
+                align: 'start',
+              }}
+              plugins={[
+                Autoplay({
+                  delay: 2500,
+                }),
+              ]}
+              className="w-full"
+              setApi={setApi}
+            >
+              <CarouselContent>
+                {bestArticleList?.list.map((bestArticle) => {
+                  return (
+                    <CarouselItem
+                      key={bestArticle.id}
+                      className="md:basis-1/2 lg:basis-1/3"
+                    >
+                      <ArticleCard type="best" articleData={bestArticle} />
+                    </CarouselItem>
+                  );
+                })}
+              </CarouselContent>
+
+              {isMobile && <Indicators api={api} />}
+            </Carousel>
+          </>
         ) : (
           <ArticleSkeleton type="best" count={PAGE_SIZE[deviceType] - 2} />
         )}

--- a/app/boards/BestArticleList.tsx
+++ b/app/boards/BestArticleList.tsx
@@ -25,7 +25,6 @@ const PAGE_SIZE = {
  */
 function BestArticleList() {
   const deviceType = useDeviceType();
-  const isMobile = deviceType === 'mobile';
 
   const [api, setApi] = useState<CarouselApi>();
 
@@ -73,7 +72,7 @@ function BestArticleList() {
                 })}
               </CarouselContent>
 
-              {isMobile && <Indicators api={api} />}
+              <Indicators api={api} />
             </Carousel>
           </>
         ) : (

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,6 +2,7 @@
 
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
+import { motion } from 'framer-motion';
 
 import Buttons from '@/components/Buttons';
 import useUser from '@/hooks/useUser';
@@ -44,13 +45,22 @@ export default function LandingPage() {
   }
 
   return (
-    <div className="mt-pr-60 flex w-screen flex-col items-center overflow-x-hidden">
+    <motion.div
+      className="mt-pr-60 flex w-screen flex-col items-center overflow-x-hidden"
+      initial={{ opacity: 0, y: 10 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true }}
+      transition={{
+        duration: 0.5,
+        delay: 0.3,
+      }}
+    >
       <section className="relative h-pr-1080 w-screen mo:h-pr-640 ta:h-pr-940">
         <Image
           src="/images/landing/img-Landing-bg.png"
           alt="background"
           fill
-          className="absolute inset-0 object-cover tamo:hidden"
+          className="floating-boat absolute inset-0 object-cover tamo:hidden"
         />
         <Image
           src="/images/landing/img-Landing-bg-ta.png"
@@ -65,21 +75,31 @@ export default function LandingPage() {
           }}
         />
 
-        <div className="absolute left-1/2 top-pr-204 flex -translate-x-1/2 flex-col items-center justify-center gap-pr-20 text-center mo:top-pr-175 mo:gap-pr-4 ta:top-pr-220">
-          <h2 className="flex gap-pr-24 whitespace-nowrap text-48sb text-t-primary mo:gap-pr-4 mo:text-24sb ta:text-40sb">
-            함께 만들어가는 투두 리스트
-            <Image
-              src="/images/landing/icon-Tool.svg"
-              alt="Tool"
-              width={56}
-              height={56}
-              className="mo:size-pr-28 ta:size-pr-48"
-            />
-          </h2>
-          <h2 className="whitespace-nowrap bg-gradient-to-r from-brand-primary to-brand-tertiary bg-clip-text text-center text-64sb text-transparent mo:text-32sb ta:text-48sb">
-            Coworkers
-          </h2>
-        </div>
+        <motion.div
+          initial={{ opacity: 0, y: 10 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          transition={{
+            duration: 0.5,
+            delay: 0.5,
+          }}
+        >
+          <div className="absolute left-1/2 top-pr-204 flex -translate-x-1/2 flex-col items-center justify-center gap-pr-20 text-center mo:top-pr-175 mo:gap-pr-4 ta:top-pr-220">
+            <h2 className="flex gap-pr-24 whitespace-nowrap text-48sb text-t-primary mo:gap-pr-4 mo:text-24sb ta:text-40sb">
+              함께 만들어가는 투두 리스트
+              <Image
+                src="/images/landing/icon-Tool.svg"
+                alt="Tool"
+                width={56}
+                height={56}
+                className="mo:size-pr-28 ta:size-pr-48"
+              />
+            </h2>
+            <h2 className="whitespace-nowrap bg-gradient-to-r from-brand-primary to-brand-tertiary bg-clip-text text-center text-64sb text-transparent mo:text-32sb ta:text-48sb">
+              Coworkers
+            </h2>
+          </div>
+        </motion.div>
 
         <div className="absolute bottom-pr-120 left-1/2 -translate-x-1/2 mo:bottom-pr-48 ta:bottom-pr-119">
           <Buttons
@@ -116,7 +136,16 @@ export default function LandingPage() {
             className="absolute inset-0 hidden object-cover mo:block"
           />
 
-          <div className="absolute top-pr-230 flex flex-col items-center mo:top-pr-123 ta:top-pr-176">
+          <motion.div
+            className="absolute top-pr-230 flex flex-col items-center mo:top-pr-123 ta:top-pr-176"
+            initial={{ opacity: 0, y: 10 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            transition={{
+              duration: 0.5,
+              delay: 0.3,
+            }}
+          >
             <h1 className="mb-pr-24 text-center text-40sb text-t-primary mo:mb-pr-16 mo:text-24sb">
               지금 바로 시작해보세요
             </h1>
@@ -124,9 +153,9 @@ export default function LandingPage() {
               팀원 모두와 같은 방향, <br className="hidden mo:block" />
               같은 속도로 나아가는 가장 쉬운 방법
             </h2>
-          </div>
+          </motion.div>
         </div>
       </footer>
-    </div>
+    </motion.div>
   );
 }

--- a/components/ArticleCard/ArticleCard.tsx
+++ b/components/ArticleCard/ArticleCard.tsx
@@ -8,7 +8,7 @@ import ArticleCardContent from '@/components/ArticleCard/ArticleCardContent';
 import ArticleCardFooter from '@/components/ArticleCard/ArticleCardFooter';
 
 const CARD_STYLE =
-  ' transition-colors hover:border-i-hover rounded-pr-12 flex flex-col border border-b-tertiary bg-b-secondary text-16sb mo:relative mo:w-full mo:px-pr-16 cursor-pointer';
+  ' transition-colors tamo:hover:border-b-tertiary hover:border-i-hover rounded-pr-12 flex flex-col border border-b-tertiary bg-b-secondary text-16sb mo:relative mo:w-full mo:px-pr-16 cursor-pointer';
 const NORMAL_STYLE =
   'h-pr-176 w-pr-590 px-pr-32 py-pr-24 mo:h-pr-162 mo:pb-pr-16 ta:w-full';
 const BEST_STYLE =

--- a/components/Indicators.tsx
+++ b/components/Indicators.tsx
@@ -1,0 +1,38 @@
+import classNames from 'classnames';
+import { useEffect, useState } from 'react';
+
+import { CarouselApi } from './ui/carousel';
+
+function Indicators({ api }: { api: CarouselApi }) {
+  const [current, setCurrent] = useState(0);
+  const [count, setCount] = useState(0);
+
+  useEffect(() => {
+    if (!api) {
+      return;
+    }
+
+    setCount(api.scrollSnapList().length);
+    setCurrent(api.selectedScrollSnap() + 1);
+
+    api.on('select', () => {
+      setCurrent(api.selectedScrollSnap() + 1);
+    });
+  }, [api]);
+
+  return (
+    <ul className="mt-pr-16 flex justify-center gap-pr-6">
+      {Array.from({ length: count }).map((_, index) => (
+        <li
+          key={index}
+          className={classNames(
+            current - 1 === index ? 'bg-t-primary' : 'bg-b-tertiary',
+            'size-pr-8 rounded-full transition-all duration-300',
+          )}
+        ></li>
+      ))}
+    </ul>
+  );
+}
+
+export default Indicators;

--- a/components/Landing/LandingCard.tsx
+++ b/components/Landing/LandingCard.tsx
@@ -1,6 +1,7 @@
 import classNames from 'classnames';
 import Image from 'next/image';
 import { ReactNode } from 'react';
+import { motion } from 'framer-motion';
 
 interface LandingCardProps {
   children: ReactNode;
@@ -40,7 +41,7 @@ function LandingCardImage({
   yPosition,
 }: LandingCardImageProps) {
   return (
-    <div
+    <motion.div
       className={classNames(
         'flex h-full w-1/2 mo:w-full',
         xPosition === 'start'
@@ -50,6 +51,13 @@ function LandingCardImage({
           ? 'items-start mo:items-center'
           : 'items-end mo:items-center',
       )}
+      initial={{ opacity: 0, y: 10 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true }}
+      transition={{
+        duration: 0.5,
+        delay: 0.5,
+      }}
     >
       <Image
         src={src}
@@ -63,7 +71,7 @@ function LandingCardImage({
             : 'ml-pr-51 tamo:ml-pr-0',
         )}
       />
-    </div>
+    </motion.div>
   );
 }
 
@@ -79,7 +87,7 @@ function LandingCardTextWrapper({
   className?: string;
 }) {
   return (
-    <div
+    <motion.div
       className={classNames(
         'flex h-full w-1/2 items-center mo:w-full',
         right
@@ -87,6 +95,13 @@ function LandingCardTextWrapper({
           : 'justify-start mo:items-start mo:justify-center',
         className,
       )}
+      initial={{ opacity: 0, y: 10 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true }}
+      transition={{
+        duration: 0.5,
+        delay: 0.8,
+      }}
     >
       <div
         className={classNames(
@@ -111,7 +126,7 @@ function LandingCardTextWrapper({
           {children}
         </div>
       </div>
-    </div>
+    </motion.div>
   );
 }
 

--- a/styles/base.css
+++ b/styles/base.css
@@ -113,6 +113,28 @@
   .scrollbar::-webkit-scrollbar-button {
     display: none;
   }
+
+  @keyframes floating-boat {
+    0% {
+      transform: translateX(0) rotate(0deg);
+    }
+    25% {
+      transform: translateX(5px) rotate(2deg);
+    }
+    50% {
+      transform: translateX(0) rotate(0deg);
+    }
+    75% {
+      transform: translateX(-5px) rotate(-2deg);
+    }
+    100% {
+      transform: translateX(0) rotate(0deg);
+    }
+  }
+
+  .floating-boat {
+    animation: floating-boat 6s linear infinite;
+  }
 }
 
 * {


### PR DESCRIPTION
Closes #340 

---

### **📌 변경 사항**

### 랜딩 페이지 애니메이션
- ✅ 다른 서브 페이지와 동일하게 랜딩 페이지 접속 시 애니메이션 적용

https://github.com/user-attachments/assets/7092fe96-b31b-4d31-b1fb-e5ee8b0c3e99

- ✅ 메인 `Visual` 이미지 좌우로 움직이는 `keyframe` 적용

https://github.com/user-attachments/assets/5b5f5cc7-550c-4e8a-a9b4-bad3867e1cfe

- ✅ `LandingCardList` 페이지 애니메이션 적용

https://github.com/user-attachments/assets/aa80a850-e136-4246-b7b6-2c7f1905d122

### 케러셀 인디케이터 추가 및 수정
- ✅ 인디케이터 재사용 가능하도록 컴포넌트 분리
- ✅ 자유게시판 리스트 페이지 인디케이터 적용 (모바일만 적용하니 데스크탑도 추가되는 것이 좋은 것 같아서 전체 해상도에 적용했습니다.)
<img width="1115" alt="스크린샷 2025-02-21 11 03 01" src="https://github.com/user-attachments/assets/71cb49e6-6734-498a-b27e-8b4cea65e039" />

- ✅ 팀 리스트(리포트) 기존 인디케이터를 공통 인디케이터 적용
<img width="360" alt="스크린샷 2025-02-21 11 03 25" src="https://github.com/user-attachments/assets/40a3db0d-d993-4c3a-bd58-5edd029b32f6" />

---

수정 요청 주신 자유게시판 스와이프 기능은 적용이 안 되어 있는 줄 알았는데 이미 적용이 되어 있어서 별다른 작업하지 않았습니다.