### PR TITLE
#346 팀페이지의 할 일 목록을 요청 시 undefined가 groupId로 전달되는 문제 해결

### DIFF
--- a/app/[teamId]/(index)/page.tsx
+++ b/app/[teamId]/(index)/page.tsx
@@ -58,11 +58,11 @@ export default function TeamPage() {
     queryKey: groupId ? ['tasks', groupId] : [],
     queryFn: () =>
       getTasksInGroup({
-        id: group?.id as number,
+        id: groupId,
         date,
       }),
     initialData: [],
-    enabled: !!group,
+    enabled: !!groupId,
   });
 
   const { mutate: onEditGroup } = useMutation({


### PR DESCRIPTION
## **✨ 팀 페이지 첫 접속 시 잘못된 경로로 요청을 보내는 문제 해결**

### **🔗 관련 이슈**

Closes #346 

---

### **📌 변경 사항**

- ✅ useParam로 받아온 groupId를 요청 시 사용하도록 변경
