### PR TITLE
#347 팀페이지 더보기 기능 구현

### DIFF
--- a/app/[teamId]/(index)/GroupTaskListWrapper.tsx
+++ b/app/[teamId]/(index)/GroupTaskListWrapper.tsx
@@ -80,8 +80,8 @@ export default function GroupTaskListWrapper({
           </button>
         )}
       </div>
-      {taskLists &&
-        sortedTaskLists?.map((taskList, i) => {
+      {sortedTaskLists ? (
+        sortedTaskLists.map((taskList, i) => {
           return more || i < SIZE ? (
             <GroupTaskList
               key={taskList.id}
@@ -92,7 +92,12 @@ export default function GroupTaskListWrapper({
               onDelete={onDelete}
             />
           ) : null;
-        })}
+        })
+      ) : (
+        <p className="my-pr-118 text-center text-16m text-t-default">
+          아직 생성된 할 일 목록이 없습니다.
+        </p>
+      )}
       {taskLists && taskLists?.length > SIZE && (
         <button
           className="m-auto flex w-fit items-center underline-offset-4 hover:underline"

--- a/app/[teamId]/(index)/GroupTaskListWrapper.tsx
+++ b/app/[teamId]/(index)/GroupTaskListWrapper.tsx
@@ -1,8 +1,11 @@
+import { useState } from 'react';
+
 import IconPlus from '@/public/images/icon-plus.svg';
 import { ITaskList } from '@/types/taskList.type';
 import { RoleType } from '@/types/group.type';
 import useModalStore from '@/stores/modalStore';
 import AddTaskList from '@/components/modal/AddTaskList';
+import ArrowDown from '@/public/images/icon-arrow-down.svg';
 
 import GroupTaskList from './GroupTaskList';
 import {
@@ -38,6 +41,9 @@ const POINT_COLOR: PointColorType[] = [
   'yellow',
 ];
 
+// 기본으로 노출되는 할 일 목록의 수
+const SIZE = 6;
+
 export default function GroupTaskListWrapper({
   role,
   taskLists,
@@ -45,6 +51,7 @@ export default function GroupTaskListWrapper({
   onEdit,
   onDelete,
 }: GroupTaskListWrapperProps) {
+  const [more, setMore] = useState(false);
   const { openModal } = useModalStore();
 
   const handleClickCreate = () =>
@@ -70,16 +77,27 @@ export default function GroupTaskListWrapper({
         )}
       </div>
       {taskLists &&
-        taskLists.map((taskList, i) => (
-          <GroupTaskList
-            key={taskList.id}
-            role={role}
-            taskList={taskList}
-            pointColor={POINT_COLOR[i % POINT_COLOR.length]}
-            onEdit={onEdit}
-            onDelete={onDelete}
-          />
-        ))}
+        taskLists.map((taskList, i) => {
+          return more || i < SIZE ? (
+            <GroupTaskList
+              key={taskList.id}
+              role={role}
+              taskList={taskList}
+              pointColor={POINT_COLOR[i % POINT_COLOR.length]}
+              onEdit={onEdit}
+              onDelete={onDelete}
+            />
+          ) : null;
+        })}
+      {taskLists && taskLists?.length > SIZE && (
+        <button
+          className="m-auto flex w-fit items-center underline-offset-4 hover:underline"
+          onClick={() => setMore((prev) => !prev)}
+        >
+          <ArrowDown className={more ? 'rotate-180' : ''} />
+          <span>{more ? '간략히' : '더보기'}</span>
+        </button>
+      )}
     </div>
   );
 }

--- a/app/[teamId]/(index)/GroupTaskListWrapper.tsx
+++ b/app/[teamId]/(index)/GroupTaskListWrapper.tsx
@@ -54,6 +54,10 @@ export default function GroupTaskListWrapper({
   const [more, setMore] = useState(false);
   const { openModal } = useModalStore();
 
+  const sortedTaskLists = taskLists?.sort(
+    (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
+  );
+
   const handleClickCreate = () =>
     openModal(<AddTaskList onCreate={onCreate} />);
 
@@ -77,7 +81,7 @@ export default function GroupTaskListWrapper({
         )}
       </div>
       {taskLists &&
-        taskLists.map((taskList, i) => {
+        sortedTaskLists?.map((taskList, i) => {
           return more || i < SIZE ? (
             <GroupTaskList
               key={taskList.id}

--- a/app/[teamId]/(index)/page.tsx
+++ b/app/[teamId]/(index)/page.tsx
@@ -176,7 +176,7 @@ export default function TeamPage() {
 
   return (
     <Container>
-      <div className="flex flex-col gap-pr-24 pt-pr-24">
+      <div className="mb-pr-84 flex flex-col gap-pr-24 pt-pr-24">
         <GroupHeader
           role={role}
           group={group}


### PR DESCRIPTION
## **✨ 팀페이지 더보기 기능 구현**

### **🔗 관련 이슈**

Closes #347 
---

### **📌 변경 사항**

- ✅ **할 일 목록이 6개를 초과할 경우 더보기 기능을 사용할 수 있습니다.**
- ✅ **할 일 목록이 응답 순서가 아닌 생성된 순서로 정렬됩니다.**
- ✅ **생성된 할 일 목록이 존재하지 않을 경우 특정 문구를 출력합니다.**
- ✅ **팀 페이지 하단 마진 추가**


---

