### PR TITLE
랜딩 애니메이션 모바일 적용 및 메타태그 추가

### DIFF
--- a/app/[teamId]/tasklist/TaskDetail.tsx
+++ b/app/[teamId]/tasklist/TaskDetail.tsx
@@ -171,6 +171,7 @@ export default function TaskDetail({
                   value={formData.name}
                   onChange={handleInputChange}
                   errorMessage={errorMessage.name}
+                  placeholder={values.name}
                 />
               ) : (
                 <>
@@ -235,6 +236,7 @@ export default function TaskDetail({
                 name="content"
                 value={formData.content}
                 onChange={handleInputChange}
+                placeholder={values.content}
               />
               <div className="mt-pr-12 flex items-center justify-end gap-pr-8">
                 <button

--- a/app/[teamId]/tasklist/page.tsx
+++ b/app/[teamId]/tasklist/page.tsx
@@ -111,6 +111,7 @@ export default function TaskListPage() {
                 queryParams: { id: taskList.id },
               })}
               key={taskList.id}
+              className="select-none"
             >
               <li
                 className={classNames(

--- a/app/boards/ArticleList.tsx
+++ b/app/boards/ArticleList.tsx
@@ -115,7 +115,7 @@ function ArticleList({ keyword }: { keyword: string | undefined }) {
             </motion.div>
           ))
         ) : (
-          <ArticleSkeleton count={4} />
+          <ArticleSkeleton count={12} />
         )}
       </div>
     </section>

--- a/app/boards/ArticleList.tsx
+++ b/app/boards/ArticleList.tsx
@@ -70,7 +70,7 @@ function ArticleList({ keyword }: { keyword: string | undefined }) {
           <Empty.Text text="조회된 게시글이 없습니다." />
         </Empty.TextWrapper>
         <Empty.ButtonWrapper>
-          <Empty.Buttons text="게시글 작성하기" href="/addarticle" />
+          <Empty.Buttons text="게시글 작성하기" href="/boards/addarticle" />
         </Empty.ButtonWrapper>
       </Empty>
     );

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -39,6 +39,10 @@ export default function RootLayout({
     <html lang="ko">
       <head>
         <meta
+          name="viewport"
+          content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
+        />
+        <meta
           name="description"
           content="Coworkers | 함께 만들어가는 Todo List"
         />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -66,10 +66,10 @@ export default function LandingPage() {
           src="/images/landing/img-Landing-bg-ta.png"
           alt="background-tablet"
           fill
-          className="absolute inset-0 hidden object-cover mo:hidden ta:block"
+          className="floating-boat absolute inset-0 hidden object-cover mo:hidden ta:block"
         />
         <div
-          className="absolute inset-0 hidden bg-cover bg-center bg-no-repeat mo:block"
+          className="floating-boat absolute inset-0 hidden bg-cover bg-center bg-no-repeat mo:block"
           style={{
             backgroundImage: "url('/images/landing/img-Landing-bg-mo.png')",
           }}

--- a/components/Empty/Empty.tsx
+++ b/components/Empty/Empty.tsx
@@ -39,7 +39,7 @@ function Empty({
         <Image
           src="/images/img-noTeam.png"
           alt="No data"
-          className="object-contain"
+          className="select-none object-contain"
           sizes="(max-width: 320px) 100vw, (max-width: 480px) 100vw, (max-width: 768px) 100vw, (max-width: 1024px) 100vw, 100vw"
           fill
           priority


### PR DESCRIPTION
Closes #351 

---

### **📌 변경 사항**

- ✅ 랜딩페이지 tablet, mobile keyframe 애니메이션 적용
- ✅ 메타태그 추가 (mobile에서 input 클릭 시 화면 확대되는 이슈)
- ✅ 할 일 리스트 날짜 변경 버튼 여러번 클릭 시 하단 텍스트 드래그 되는 현상 수정
- ✅ 자유게시판 정렬 기능 시 스크롤 위치 변하는 이슈 수정
- ✅ 할 일 상세 수정 input, textarea placeholder 적용
 
---

### 랜딩페이지
랜딩 페이지의 최상단 백그라운드 이미지가 움직이는 모션의 경우, 아예 제거를 해버릴까 했는데 또 막상 없으면 너무 허전한 것 같아서 우선은 tablet, mobile 해상도 둘 다 적용하는 것으로 결정했습니다.

혹시나 확인해보시고 없는게 더 낫다고 생각드시는 분이 계시다면 말씀 부탁드릴게요 ㅜㅜ 저도 잘 모르겠어서 일단은 추가했습니다..😅

### 자유게시판 정렬 시 스크롤 위치 이슈
해당 이슈의 경우 정렬을 바꾸는 순간 스켈레톤이 노출되는데 스켈레톤의 갯수가 적어서 그에 맞는 페이지 높이?가 순간 변경되어 스크롤 위치가 달라지는 것 같아서 스켈레톤 갯수를 늘려 해결하였습니다. tablet, mobile에서도 확인했습니다.

---

하나의 PR에 지금 수정된 내용이 많아보이는데 코드 수정이 한 줄씩 밖에 수정이 되지 않아 리뷰함에 있어서 문제가 없을 것 같다고 판단되어 하나의 PR에 올렸습니다.
혹시나 불편하신 분들 계시다면 양해 부탁드립니다..🥲