### PR TITLE
📝 댓글 컴포넌트 수정 시 textarea focus 적용

### DIFF
--- a/components/Comment/Comment.tsx
+++ b/components/Comment/Comment.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, useState } from 'react';
+import { ChangeEvent, useEffect, useRef, useState } from 'react';
 import classNames from 'classnames';
 
 import { Card } from '@/components/ui/card';
@@ -36,6 +36,8 @@ function Comment({
   const [commentEditContent, setCommentEditContent] = useState(content);
   const [commentEdit, setCommentEdit] = useState(false);
 
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+
   const { openModal } = useModalStore();
 
   const isArticleComment = type === 'article';
@@ -47,18 +49,31 @@ function Comment({
     : undefined;
   const user = isTaskComment ? (commentData as ITaskComment).user : undefined;
 
+  // 댓글 수정 시 textarea focus
+  useEffect(() => {
+    if (commentEdit && textareaRef.current) {
+      const textarea = textareaRef.current;
+      textarea.focus();
+
+      // 커서를 맨 뒤로 이동
+      textarea.setSelectionRange(
+        commentEditContent.length,
+        commentEditContent.length,
+      );
+    }
+  }, [commentEdit, commentEditContent]);
+
   // 수정 완료
   const updateSubmit = () => {
-    setCommentEdit(false);
-
-    if (taskId)
-      return handleUpdateSubmit({
+    if (taskId) {
+      handleUpdateSubmit({
         taskId,
         commentId: id,
         content: commentEditContent,
       });
-    else
-      return openModal(
+      setCommentEdit(false);
+    } else {
+      openModal(
         <EditDelete
           title="댓글"
           actionType="수정"
@@ -68,6 +83,7 @@ function Comment({
           }}
         />,
       );
+    }
   };
 
   return (
@@ -89,6 +105,7 @@ function Comment({
       ) : (
         <div className="mb-pr-16">
           <TextareaField
+            ref={textareaRef}
             name="content"
             size="md"
             value={commentEditContent}

--- a/types/inputField.type.ts
+++ b/types/inputField.type.ts
@@ -20,4 +20,5 @@ export interface TextareaFieldProps
   size?: 'md' | 'lg';
   height?: string;
   onChange?: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+  ref?: React.Ref<HTMLTextAreaElement>;
 }


### PR DESCRIPTION
Closes #353 

---

### **📌 변경 사항**

- ✅ 댓글 컴포넌트 수정 시 textarea focus 적용하였습니다.
댓글 수정 시 textarea focus되며, 댓글 문자열 가장 뒤에 커서가 생기도록 작업하였습니다.

### 할 일 상세 댓글
https://github.com/user-attachments/assets/53a900cb-048b-49f8-adc0-a8fed3f80c40

### 자유게시판 게시글 댓글
https://github.com/user-attachments/assets/7db06d62-3a33-47d7-b15c-98f02d8460b2
