### PR TITLE
🔨 oauthForm 컴포넌트 ref 제거

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -88,7 +88,9 @@ function LoginPage() {
 
   const hasDisabled =
     requiredFields.some(
-      (field) => !changedFields[field as keyof typeof changedFields],
+      (field) =>
+        !formData[field as keyof typeof formData] &&
+        !changedFields[field as keyof typeof changedFields],
     ) ||
     requiredFields.some(
       (field) => errorMessage[field as keyof typeof errorMessage] !== '',

--- a/components/OauthForm.tsx
+++ b/components/OauthForm.tsx
@@ -1,6 +1,6 @@
 import { useMutation } from '@tanstack/react-query';
 import { signIn, useSession } from 'next-auth/react';
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect } from 'react';
 
 import { signInProvider } from '@/service/auth.api';
 import useUser from '@/hooks/useUser';
@@ -10,8 +10,8 @@ import { useSnackbar } from '@/contexts/SnackBar.context';
 import useUserStore from '@/stores/useUser.store';
 
 export default function OauthForm({ type }: { type: 'login' | 'signup' }) {
-  const { reload } = useUser();
-  const user = useUserStore((state) => state.user);
+  const { user, reload } = useUser();
+
   const { showSnackbar } = useSnackbar();
 
   const { data: session } = useSession();
@@ -46,12 +46,8 @@ export default function OauthForm({ type }: { type: 'login' | 'signup' }) {
     signIn('kakao', { redirect: false });
   }, []);
 
-  const isExecuted = useRef(false);
-
   useEffect(() => {
-    if (!session || isExecuted.current) return;
-
-    isExecuted.current = true;
+    if (!session) return;
 
     if (session?.googleIdToken) {
       // STUB 유저 정보가 없고, 구글 로그인 데이터가 있을 때


### PR DESCRIPTION
### **🔗 관련 이슈**

Closes #362

---

### **📌 변경 사항**

- ✅ **[Oauth Form ref]** 제거
- ✅ **[로그인 자동완성 버튼 활성화]** 안됐던 문제 수정

---

### **🚀 기대 효과**

✔ **이슈 개선**: [로그인 기능 원복]  

---

### **🛠 테스트 내역**

- [x] **API 요청 정상 처리 확인**

---

### **💬 리뷰 요청 사항**

- 생각해보니 배포 하고나서는 소셜 로그인 확인을 제대로 못했었는데, 개발 모드에서 정상적으로 로딩 없이 진행되었던 방식이 ref를 넣기 전 버전이었던것같아서 ref 제거 한 채로 배포 부탁드립니다.
- 원래는 중복호출을 막고자 한건데 혹시나 싶어서 테스트 배포 부탁드립니다
