### PR TITLE
#358 네비게이션 드롭다운에 선택된 팀의 프로필 이미지 표기

### DIFF
--- a/components/NavigationGroupDropdown/DropdownAddGroup.tsx
+++ b/components/NavigationGroupDropdown/DropdownAddGroup.tsx
@@ -21,7 +21,7 @@ export default function DropdownAddGroup() {
         backgroundColor="none"
         border="default"
         onClick={handleClick}
-        className="text-t-primary"
+        className="cursor-pointer text-t-primary"
         icon={
           <IconPlus
             className="text-t-primary"

--- a/components/NavigationGroupDropdown/DropdownTab.tsx
+++ b/components/NavigationGroupDropdown/DropdownTab.tsx
@@ -21,7 +21,7 @@ export default function DropdownTab({ group, onClick }: DropdownTabProps) {
 
   return (
     <DropdownMenuItem
-      className="mb-pr-8 rounded-lg px-pr-8 py-pr-7"
+      className="mb-pr-8 cursor-pointer rounded-lg px-pr-8 py-pr-7"
       onClick={handleClick}
     >
       <div className="relative size-pr-24 overflow-hidden rounded-pr-6">

--- a/components/NavigationGroupDropdown/NavigationGroupDropdown.tsx
+++ b/components/NavigationGroupDropdown/NavigationGroupDropdown.tsx
@@ -11,6 +11,9 @@ import ArrowDwon from '@/public/images/icon-arrow-down.svg';
 import { Button } from '../ui/button';
 import DropdownTab from './DropdownTab';
 import DropdownAddGroup from './DropdownAddGroup';
+import Image from 'next/image';
+
+const DEFAULT_GROUP_PROFILE = '/images/icon-image-default.svg';
 
 interface NavigationGroupDropdownProps {
   groups: IGroup[] | null;
@@ -39,11 +42,24 @@ export default function NavigationGroupDropdown({
       <DropdownMenuTrigger asChild>
         <Button variant="link" className="bg-inherit text-t-primary">
           {/* TODO 펜딩 시 스피너 렌더링 해야함 */}
-          {isPending ? (
-            <span>로딩 중</span>
-          ) : (
-            <span className="text-16m">{currentGroup?.name || '팀 선택'}</span>
+          {isPending && <span className="text-16m">로딩 중</span>}
+          {!isPending && !currentGroup && (
+            <span className="text-16m">팀 선택</span>
           )}
+          {!isPending && currentGroup && (
+            <>
+              <div className="relative size-pr-24 overflow-hidden rounded-pr-6">
+                <Image
+                  fill
+                  className="object-cover"
+                  src={currentGroup.image || DEFAULT_GROUP_PROFILE}
+                  alt="프로필 옵션"
+                />
+              </div>
+              <span className="text-16m">{currentGroup.name}</span>
+            </>
+          )}
+
           <ArrowDwon />
         </Button>
       </DropdownMenuTrigger>

--- a/components/NavigationGroupDropdown/NavigationGroupDropdown.tsx
+++ b/components/NavigationGroupDropdown/NavigationGroupDropdown.tsx
@@ -1,4 +1,5 @@
 import { useRouter } from 'next/navigation';
+import Image from 'next/image';
 
 import { IGroup } from '@/types/group.type';
 import {
@@ -11,7 +12,6 @@ import ArrowDwon from '@/public/images/icon-arrow-down.svg';
 import { Button } from '../ui/button';
 import DropdownTab from './DropdownTab';
 import DropdownAddGroup from './DropdownAddGroup';
-import Image from 'next/image';
 
 const DEFAULT_GROUP_PROFILE = '/images/icon-image-default.svg';
 

--- a/components/layout/Header/HeadersGnb.tsx
+++ b/components/layout/Header/HeadersGnb.tsx
@@ -11,22 +11,20 @@ function HeadersGnb() {
 
   return (
     <nav className="flex flex-1 items-center gap-pr-40 mo:hidden ta:gap-pr-24">
-      <div className="space-x-pr-8">
-        {groups && (
-          <NavigationGroupDropdown
-            groups={groups}
-            isPending={isPending}
-            currentGroup={group}
-          />
-        )}
-        {user && (
-          <Link href="/boards">
-            <Button variant="link">
-              <span className="text-16m">자유게시판</span>
-            </Button>
-          </Link>
-        )}
-      </div>
+      {groups && (
+        <NavigationGroupDropdown
+          groups={groups}
+          isPending={isPending}
+          currentGroup={group}
+        />
+      )}
+      {user && (
+        <Link href="/boards">
+          <Button variant="link">
+            <span className="text-16m">자유게시판</span>
+          </Button>
+        </Link>
+      )}
     </nav>
   );
 }


### PR DESCRIPTION
## **✨ 네비게이션 드롭다운에 선택된 팀의 프로필 이미지 표기**

### **🔗 관련 이슈**

Closes #358

---

### **📌 변경 사항**

- ✅ 드롭다운에 선택된 팀의 프로필 이미지 표기
- ✅ 드롭다운 아이템에 cursor-pointer 적용
